### PR TITLE
Reduce Cursor Composer provider token usage for large Pi tool results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 *$py.class
 .pytest_cache/
 pi-skill-repo-explorer/skills/repo-explorer/repo-explorer-effectiveness-*.md
+pi-extension-cursor-composer/benchmark-output/

--- a/pi-extension-cursor-composer/README.md
+++ b/pi-extension-cursor-composer/README.md
@@ -95,6 +95,10 @@ Provider usage/status behavior:
 - Set `CURSOR_COMPOSER_PROVIDER_HEARTBEAT_MS=0` or `false` to disable heartbeats entirely.
 - Set `CURSOR_COMPOSER_PROVIDER_AUTO_REVIEW=false` to disable Cursor local auto-review.
 - Set `CURSOR_COMPOSER_PROVIDER_SANDBOX=true` to enable Cursor SDK sandboxing for native model runs.
+- Large Pi `toolResult` messages are truncated by default before they are replayed into the native provider prompt. This keeps previous `read`/`bash` dumps from being resent to Cursor on every turn while preserving the message header, preview, original size, and instructions to re-read/rerun if exact content is needed.
+- Set `CURSOR_COMPOSER_PROVIDER_TRUNCATE_TOOL_RESULTS=false` to restore the previous full tool-result replay behavior.
+- Tune truncation with `CURSOR_COMPOSER_PROVIDER_TOOL_RESULT_MAX_BYTES` and `CURSOR_COMPOSER_PROVIDER_TOOL_RESULT_MAX_LINES`.
+
 
 ## Tool
 
@@ -107,3 +111,27 @@ export CURSOR_COMPOSER_REQUIRE_CONFIRMATION=false
 ```
 
 Use that only if you accept unattended Cursor SDK tool execution.
+
+## Development tests
+
+Offline serialization tests do not call Cursor:
+
+```bash
+cd pi-extension-cursor-composer
+npm install
+npm test
+```
+
+Live smoke tests call Cursor in `plan` mode and print prompt byte counts plus SDK-reported usage for baseline full replay versus optimized tool-result truncation:
+
+```bash
+cd pi-extension-cursor-composer
+CURSOR_COMPOSER_LIVE_SMOKE=true npm run smoke:cursor
+```
+
+A longer live benchmark runs the same multi-turn fixture twice — first with original full tool-result replay, then with optimized truncation — and writes JSONL records plus a summary under `benchmark-output/`:
+
+```bash
+cd pi-extension-cursor-composer
+CURSOR_COMPOSER_LIVE_BENCHMARK=true npm run benchmark:cursor
+```

--- a/pi-extension-cursor-composer/README.md
+++ b/pi-extension-cursor-composer/README.md
@@ -95,9 +95,8 @@ Provider usage/status behavior:
 - Set `CURSOR_COMPOSER_PROVIDER_HEARTBEAT_MS=0` or `false` to disable heartbeats entirely.
 - Set `CURSOR_COMPOSER_PROVIDER_AUTO_REVIEW=false` to disable Cursor local auto-review.
 - Set `CURSOR_COMPOSER_PROVIDER_SANDBOX=true` to enable Cursor SDK sandboxing for native model runs.
-- Large Pi `toolResult` messages are truncated by default before they are replayed into the native provider prompt. This keeps previous `read`/`bash` dumps from being resent to Cursor on every turn while preserving the message header, preview, original size, and instructions to re-read/rerun if exact content is needed.
+- Large Pi `toolResult` messages are truncated by default before they are replayed into the native provider prompt. This keeps previous `read`/`bash` dumps from being resent to Cursor on every turn while preserving the message header, head/tail previews, original size, content hash, and instructions to re-read/rerun when exact omitted content is needed. Truncation uses Pi's normal tool-output byte and line limits.
 - Set `CURSOR_COMPOSER_PROVIDER_TRUNCATE_TOOL_RESULTS=false` to restore the previous full tool-result replay behavior.
-- Tune truncation with `CURSOR_COMPOSER_PROVIDER_TOOL_RESULT_MAX_BYTES` and `CURSOR_COMPOSER_PROVIDER_TOOL_RESULT_MAX_LINES`.
 
 
 ## Tool
@@ -111,27 +110,3 @@ export CURSOR_COMPOSER_REQUIRE_CONFIRMATION=false
 ```
 
 Use that only if you accept unattended Cursor SDK tool execution.
-
-## Development tests
-
-Offline serialization tests do not call Cursor:
-
-```bash
-cd pi-extension-cursor-composer
-npm install
-npm test
-```
-
-Live smoke tests call Cursor in `plan` mode and print prompt byte counts plus SDK-reported usage for baseline full replay versus optimized tool-result truncation:
-
-```bash
-cd pi-extension-cursor-composer
-CURSOR_COMPOSER_LIVE_SMOKE=true npm run smoke:cursor
-```
-
-A longer live benchmark runs the same multi-turn fixture twice — first with original full tool-result replay, then with optimized truncation — and writes JSONL records plus a summary under `benchmark-output/`:
-
-```bash
-cd pi-extension-cursor-composer
-CURSOR_COMPOSER_LIVE_BENCHMARK=true npm run benchmark:cursor
-```

--- a/pi-extension-cursor-composer/README.md
+++ b/pi-extension-cursor-composer/README.md
@@ -95,7 +95,8 @@ Provider usage/status behavior:
 - Set `CURSOR_COMPOSER_PROVIDER_HEARTBEAT_MS=0` or `false` to disable heartbeats entirely.
 - Set `CURSOR_COMPOSER_PROVIDER_AUTO_REVIEW=false` to disable Cursor local auto-review.
 - Set `CURSOR_COMPOSER_PROVIDER_SANDBOX=true` to enable Cursor SDK sandboxing for native model runs.
-- Large Pi `toolResult` messages are truncated by default before they are replayed into the native provider prompt. This keeps previous `read`/`bash` dumps from being resent to Cursor on every turn while preserving the message header, head/tail previews, original size, content hash, and instructions to re-read/rerun when exact omitted content is needed. Truncation uses Pi's normal tool-output byte and line limits.
+- Large Pi `toolResult` messages are truncated by default before they are replayed into the native provider prompt. This keeps previous `read`/`bash` dumps from being resent to Cursor on every turn while preserving the message header, head/tail previews, original size, content hash, and a deterministic Recovery ID. Truncation uses Pi's normal tool-output byte and line limits.
+- When a provider prompt contains truncated tool results, the local Cursor agent also receives an ephemeral `pi_get_truncated_tool_result` custom tool. Composer can call it with the Recovery ID and an optional line range to fetch exact omitted historical content for that provider run without replaying every large output up front. Recovery IDs are deterministic for the same persisted tool result, but the recovery map itself is rebuilt per provider run rather than stored separately.
 - Set `CURSOR_COMPOSER_PROVIDER_TRUNCATE_TOOL_RESULTS=false` to restore the previous full tool-result replay behavior.
 
 

--- a/pi-extension-cursor-composer/context.ts
+++ b/pi-extension-cursor-composer/context.ts
@@ -1,10 +1,34 @@
-const DEFAULT_PROVIDER_TOOL_RESULT_MAX_BYTES = 32_000;
-const DEFAULT_PROVIDER_TOOL_RESULT_MAX_LINES = 500;
+import { createHash } from "node:crypto";
+
+// Keep provider replay truncation aligned with Pi's normal tool-output truncation defaults.
+// These mirror @earendil-works/pi-coding-agent DEFAULT_MAX_BYTES / DEFAULT_MAX_LINES
+// without adding a test-time dependency on Pi internals for this source-repo package.
+export const DEFAULT_PROVIDER_TOOL_RESULT_MAX_BYTES = 51_200;
+export const DEFAULT_PROVIDER_TOOL_RESULT_MAX_LINES = 2_000;
 
 export type ProviderToolResultSerializationOptions = {
 	truncateToolResults: boolean;
 	maxToolResultBytes: number;
 	maxToolResultLines: number;
+};
+
+export type TruncatedToolResultMetadata = {
+	toolName: string;
+	originalBytes: number;
+	originalLines: number;
+	previewBytes: number;
+	previewLines: number;
+	omittedBytes: number;
+	sha256: string;
+};
+
+export type ProviderContextSerializationMetadata = {
+	truncatedToolResults: TruncatedToolResultMetadata[];
+};
+
+export type ProviderContextSerializationResult = {
+	prompt: string;
+	metadata: ProviderContextSerializationMetadata;
 };
 
 export type ProviderContextSerializationOptions = Partial<ProviderToolResultSerializationOptions> & {
@@ -17,11 +41,14 @@ export type ProviderContextSerializationOptions = Partial<ProviderToolResultSeri
 
 type TextPreview = {
 	text: string;
+	headText: string;
+	tailText: string;
 	truncated: boolean;
 	originalBytes: number;
 	originalLines: number;
 	previewBytes: number;
 	previewLines: number;
+	sha256: string;
 };
 
 function envBoolean(value: string | undefined, fallback: boolean): boolean {
@@ -32,12 +59,6 @@ function envBoolean(value: string | undefined, fallback: boolean): boolean {
 	return fallback;
 }
 
-function envPositiveInteger(value: string | undefined, fallback: number): number {
-	const parsed = value ? Number(value) : NaN;
-	if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
-	return Math.floor(parsed);
-}
-
 function byteLength(text: string): number {
 	return Buffer.byteLength(text, "utf8");
 }
@@ -45,6 +66,10 @@ function byteLength(text: string): number {
 function lineCount(text: string): number {
 	if (!text) return 0;
 	return text.split(/\r?\n/).length;
+}
+
+function sha256(text: string): string {
+	return createHash("sha256").update(text).digest("hex");
 }
 
 function formatBytes(bytes: number): string {
@@ -64,19 +89,68 @@ function normalizeText(value: unknown): string {
 	}
 }
 
+function clipTextToBytes(text: string, maxBytes: number): string {
+	if (byteLength(text) <= maxBytes) return text;
+	let clipped = "";
+	for (const char of text) {
+		if (byteLength(clipped + char) > maxBytes) break;
+		clipped += char;
+	}
+	return clipped;
+}
+
+function takeHead(lines: string[], maxLines: number, maxBytes: number): string {
+	const selected = lines.slice(0, Math.max(0, maxLines));
+	const parts: string[] = [];
+	let usedBytes = 0;
+	for (const line of selected) {
+		const prefix = parts.length === 0 ? "" : "\n";
+		const candidate = `${prefix}${line}`;
+		const candidateBytes = byteLength(candidate);
+		if (usedBytes + candidateBytes > maxBytes) {
+			const remaining = Math.max(0, maxBytes - usedBytes - byteLength(prefix));
+			const clipped = clipTextToBytes(line, remaining);
+			if (clipped) parts.push(`${prefix}${clipped}`);
+			break;
+		}
+		parts.push(candidate);
+		usedBytes += candidateBytes;
+	}
+	return parts.join("");
+}
+
+function takeTail(lines: string[], maxLines: number, maxBytes: number): string {
+	const selected = lines.slice(Math.max(0, lines.length - Math.max(0, maxLines)));
+	const parts: string[] = [];
+	let usedBytes = 0;
+	for (let index = selected.length - 1; index >= 0; index -= 1) {
+		const line = selected[index];
+		const suffix = parts.length === 0 ? "" : "\n";
+		const candidate = `${line}${suffix}`;
+		const candidateBytes = byteLength(candidate);
+		if (usedBytes + candidateBytes > maxBytes) {
+			const remaining = Math.max(0, maxBytes - usedBytes - byteLength(suffix));
+			const clipped = clipTextToBytes(line, remaining);
+			if (clipped) parts.unshift(`${clipped}${suffix}`);
+			break;
+		}
+		parts.unshift(candidate);
+		usedBytes += candidateBytes;
+	}
+	return parts.join("");
+}
+
 export function providerToolResultSerializationOptionsFromEnv(
 	env: NodeJS.ProcessEnv = process.env,
+	defaults: Pick<ProviderToolResultSerializationOptions, "maxToolResultBytes" | "maxToolResultLines"> = {
+		maxToolResultBytes: DEFAULT_PROVIDER_TOOL_RESULT_MAX_BYTES,
+		maxToolResultLines: DEFAULT_PROVIDER_TOOL_RESULT_MAX_LINES,
+	},
 ): ProviderToolResultSerializationOptions {
 	return {
 		truncateToolResults: envBoolean(env.CURSOR_COMPOSER_PROVIDER_TRUNCATE_TOOL_RESULTS, true),
-		maxToolResultBytes: envPositiveInteger(
-			env.CURSOR_COMPOSER_PROVIDER_TOOL_RESULT_MAX_BYTES,
-			DEFAULT_PROVIDER_TOOL_RESULT_MAX_BYTES,
-		),
-		maxToolResultLines: envPositiveInteger(
-			env.CURSOR_COMPOSER_PROVIDER_TOOL_RESULT_MAX_LINES,
-			DEFAULT_PROVIDER_TOOL_RESULT_MAX_LINES,
-		),
+		maxToolResultBytes: defaults.maxToolResultBytes,
+		maxToolResultLines: defaults.maxToolResultLines,
 	};
 }
 
@@ -102,78 +176,92 @@ export function previewTextByBytesAndLines(
 ): TextPreview {
 	const originalBytes = byteLength(text);
 	const originalLines = lineCount(text);
+	const digest = sha256(text);
 	if (originalBytes <= maxBytes && originalLines <= maxLines) {
 		return {
 			text,
+			headText: text,
+			tailText: "",
 			truncated: false,
 			originalBytes,
 			originalLines,
 			previewBytes: originalBytes,
 			previewLines: originalLines,
+			sha256: digest,
 		};
 	}
 
-	const lines = text.split(/\r?\n/).slice(0, Math.max(0, maxLines));
-	const previewParts: string[] = [];
-	let usedBytes = 0;
-	for (const line of lines) {
-		const suffix = previewParts.length === 0 ? "" : "\n";
-		const candidate = `${suffix}${line}`;
-		const candidateBytes = byteLength(candidate);
-		if (usedBytes + candidateBytes > maxBytes) {
-			const remaining = Math.max(0, maxBytes - usedBytes - byteLength(suffix));
-			if (remaining > 0) {
-				let clipped = "";
-				for (const char of line) {
-					if (byteLength(clipped + char) > remaining) break;
-					clipped += char;
-				}
-				if (clipped) previewParts.push(`${suffix}${clipped}`);
-			}
-			break;
-		}
-		previewParts.push(candidate);
-		usedBytes += candidateBytes;
-	}
+	const lines = text.split(/\r?\n/);
+	const headLineBudget = Math.max(1, Math.ceil(maxLines / 2));
+	const tailLineBudget = Math.max(0, maxLines - headLineBudget);
+	const headByteBudget = Math.max(1, Math.ceil(maxBytes / 2));
+	const tailByteBudget = Math.max(0, maxBytes - headByteBudget);
+	const headText = takeHead(lines, headLineBudget, headByteBudget);
+	const tailText = tailLineBudget > 0 && tailByteBudget > 0 ? takeTail(lines, tailLineBudget, tailByteBudget) : "";
+	const textParts = [headText];
+	if (tailText) textParts.push("[... middle omitted ...]", tailText);
+	const previewText = textParts.filter(Boolean).join("\n");
 
-	const preview = previewParts.join("");
 	return {
-		text: preview,
+		text: previewText,
+		headText,
+		tailText,
 		truncated: true,
 		originalBytes,
 		originalLines,
-		previewBytes: byteLength(preview),
-		previewLines: lineCount(preview),
+		previewBytes: byteLength(headText) + byteLength(tailText),
+		previewLines: lineCount(headText) + lineCount(tailText),
+		sha256: digest,
 	};
 }
 
 export function serializeToolResultContent(
 	content: unknown,
 	options: ProviderToolResultSerializationOptions,
+	metadata?: { toolName?: string; truncatedToolResults?: TruncatedToolResultMetadata[] },
 ): string {
 	const text = contentToText(content);
 	if (!options.truncateToolResults) return text;
 	const preview = previewTextByBytesAndLines(text, options.maxToolResultBytes, options.maxToolResultLines);
 	if (!preview.truncated) return text;
+	const toolName = metadata?.toolName ?? "tool";
+	metadata?.truncatedToolResults?.push({
+		toolName,
+		originalBytes: preview.originalBytes,
+		originalLines: preview.originalLines,
+		previewBytes: preview.previewBytes,
+		previewLines: preview.previewLines,
+		omittedBytes: Math.max(0, preview.originalBytes - preview.previewBytes),
+		sha256: preview.sha256,
+	});
 	return [
 		"[Large tool result truncated by Pi Cursor provider wrapper]",
+		`Tool: ${toolName}.`,
 		`Original: ${preview.originalLines} lines, ${formatBytes(preview.originalBytes)}.`,
 		`Included preview: ${preview.previewLines} lines, ${formatBytes(preview.previewBytes)}.`,
+		`Original SHA-256: ${preview.sha256}.`,
 		"Reason: avoid resending very large prior Pi tool outputs to Cursor Composer on every provider turn.",
-		"If exact content is needed, use available tools to re-read the referenced file or re-run the relevant command from the conversation context.",
+		"If exact historical content is required, disable CURSOR_COMPOSER_PROVIDER_TRUNCATE_TOOL_RESULTS or use available tools to re-read/rerun when safe and equivalent.",
 		"",
-		"<tool_result_preview>",
-		preview.text,
-		"</tool_result_preview>",
+		"<tool_result_preview_head>",
+		preview.headText,
+		"</tool_result_preview_head>",
+		...(preview.tailText
+			? ["", "<tool_result_preview_tail>", preview.tailText, "</tool_result_preview_tail>"]
+			: []),
 	].join("\n");
 }
 
-export function serializeProviderContext(context: unknown, options: ProviderContextSerializationOptions = {}): string {
+export function serializeProviderContextWithMetadata(
+	context: unknown,
+	options: ProviderContextSerializationOptions = {},
+): ProviderContextSerializationResult {
 	const contextObject = (context ?? {}) as any;
 	const toolOptions: ProviderToolResultSerializationOptions = {
 		...providerToolResultSerializationOptionsFromEnv(),
 		...options,
 	};
+	const metadata: ProviderContextSerializationMetadata = { truncatedToolResults: [] };
 	const includeSystemPrompt = options.includeSystemPrompt ?? true;
 	const systemPrompt = options.systemPrompt ?? contextObject.systemPrompt;
 	const messages = options.messages ?? contextObject.messages ?? [];
@@ -188,14 +276,22 @@ export function serializeProviderContext(context: unknown, options: ProviderCont
 	lines.push("# Task", ...taskLines, "", options.conversationTitle ?? "# Conversation");
 	for (const message of messages as any[]) {
 		if (message?.role === "toolResult") {
+			const toolName = message.toolName ?? "tool";
 			lines.push(
-				`## toolResult ${message.toolName ?? "tool"}`,
-				serializeToolResultContent(message.content, toolOptions),
+				`## toolResult ${toolName}`,
+				serializeToolResultContent(message.content, toolOptions, {
+					toolName,
+					truncatedToolResults: metadata.truncatedToolResults,
+				}),
 				"",
 			);
 		} else {
 			lines.push(`## ${message?.role ?? "message"}`, contentToText(message?.content), "");
 		}
 	}
-	return lines.join("\n").trim();
+	return { prompt: lines.join("\n").trim(), metadata };
+}
+
+export function serializeProviderContext(context: unknown, options: ProviderContextSerializationOptions = {}): string {
+	return serializeProviderContextWithMetadata(context, options).prompt;
 }

--- a/pi-extension-cursor-composer/context.ts
+++ b/pi-extension-cursor-composer/context.ts
@@ -1,0 +1,201 @@
+const DEFAULT_PROVIDER_TOOL_RESULT_MAX_BYTES = 32_000;
+const DEFAULT_PROVIDER_TOOL_RESULT_MAX_LINES = 500;
+
+export type ProviderToolResultSerializationOptions = {
+	truncateToolResults: boolean;
+	maxToolResultBytes: number;
+	maxToolResultLines: number;
+};
+
+export type ProviderContextSerializationOptions = Partial<ProviderToolResultSerializationOptions> & {
+	includeSystemPrompt?: boolean;
+	systemPrompt?: string;
+	messages?: unknown[];
+	taskLines?: string[];
+	conversationTitle?: string;
+};
+
+type TextPreview = {
+	text: string;
+	truncated: boolean;
+	originalBytes: number;
+	originalLines: number;
+	previewBytes: number;
+	previewLines: number;
+};
+
+function envBoolean(value: string | undefined, fallback: boolean): boolean {
+	if (value === undefined) return fallback;
+	const normalized = value.trim().toLowerCase();
+	if (["0", "false", "no", "off"].includes(normalized)) return false;
+	if (["1", "true", "yes", "on"].includes(normalized)) return true;
+	return fallback;
+}
+
+function envPositiveInteger(value: string | undefined, fallback: number): number {
+	const parsed = value ? Number(value) : NaN;
+	if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+	return Math.floor(parsed);
+}
+
+function byteLength(text: string): number {
+	return Buffer.byteLength(text, "utf8");
+}
+
+function lineCount(text: string): number {
+	if (!text) return 0;
+	return text.split(/\r?\n/).length;
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	const kib = bytes / 1024;
+	if (kib < 1024) return `${kib.toFixed(1)} KiB`;
+	return `${(kib / 1024).toFixed(1)} MiB`;
+}
+
+function normalizeText(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (value == null) return "";
+	try {
+		return JSON.stringify(value, null, 2);
+	} catch {
+		return String(value);
+	}
+}
+
+export function providerToolResultSerializationOptionsFromEnv(
+	env: NodeJS.ProcessEnv = process.env,
+): ProviderToolResultSerializationOptions {
+	return {
+		truncateToolResults: envBoolean(env.CURSOR_COMPOSER_PROVIDER_TRUNCATE_TOOL_RESULTS, true),
+		maxToolResultBytes: envPositiveInteger(
+			env.CURSOR_COMPOSER_PROVIDER_TOOL_RESULT_MAX_BYTES,
+			DEFAULT_PROVIDER_TOOL_RESULT_MAX_BYTES,
+		),
+		maxToolResultLines: envPositiveInteger(
+			env.CURSOR_COMPOSER_PROVIDER_TOOL_RESULT_MAX_LINES,
+			DEFAULT_PROVIDER_TOOL_RESULT_MAX_LINES,
+		),
+	};
+}
+
+export function contentToText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return normalizeText(content);
+	return content
+		.map((block: any) => {
+			if (block?.type === "text") return block.text ?? "";
+			if (block?.type === "thinking") return `[thinking]\n${block.thinking ?? ""}`;
+			if (block?.type === "toolCall") return `[tool call: ${block.name ?? "unknown"}]\n${normalizeText(block.arguments)}`;
+			if (block?.type === "image") return "[image omitted by Pi Cursor provider wrapper]";
+			return normalizeText(block);
+		})
+		.filter(Boolean)
+		.join("\n");
+}
+
+export function previewTextByBytesAndLines(
+	text: string,
+	maxBytes: number,
+	maxLines: number,
+): TextPreview {
+	const originalBytes = byteLength(text);
+	const originalLines = lineCount(text);
+	if (originalBytes <= maxBytes && originalLines <= maxLines) {
+		return {
+			text,
+			truncated: false,
+			originalBytes,
+			originalLines,
+			previewBytes: originalBytes,
+			previewLines: originalLines,
+		};
+	}
+
+	const lines = text.split(/\r?\n/).slice(0, Math.max(0, maxLines));
+	const previewParts: string[] = [];
+	let usedBytes = 0;
+	for (const line of lines) {
+		const suffix = previewParts.length === 0 ? "" : "\n";
+		const candidate = `${suffix}${line}`;
+		const candidateBytes = byteLength(candidate);
+		if (usedBytes + candidateBytes > maxBytes) {
+			const remaining = Math.max(0, maxBytes - usedBytes - byteLength(suffix));
+			if (remaining > 0) {
+				let clipped = "";
+				for (const char of line) {
+					if (byteLength(clipped + char) > remaining) break;
+					clipped += char;
+				}
+				if (clipped) previewParts.push(`${suffix}${clipped}`);
+			}
+			break;
+		}
+		previewParts.push(candidate);
+		usedBytes += candidateBytes;
+	}
+
+	const preview = previewParts.join("");
+	return {
+		text: preview,
+		truncated: true,
+		originalBytes,
+		originalLines,
+		previewBytes: byteLength(preview),
+		previewLines: lineCount(preview),
+	};
+}
+
+export function serializeToolResultContent(
+	content: unknown,
+	options: ProviderToolResultSerializationOptions,
+): string {
+	const text = contentToText(content);
+	if (!options.truncateToolResults) return text;
+	const preview = previewTextByBytesAndLines(text, options.maxToolResultBytes, options.maxToolResultLines);
+	if (!preview.truncated) return text;
+	return [
+		"[Large tool result truncated by Pi Cursor provider wrapper]",
+		`Original: ${preview.originalLines} lines, ${formatBytes(preview.originalBytes)}.`,
+		`Included preview: ${preview.previewLines} lines, ${formatBytes(preview.previewBytes)}.`,
+		"Reason: avoid resending very large prior Pi tool outputs to Cursor Composer on every provider turn.",
+		"If exact content is needed, use available tools to re-read the referenced file or re-run the relevant command from the conversation context.",
+		"",
+		"<tool_result_preview>",
+		preview.text,
+		"</tool_result_preview>",
+	].join("\n");
+}
+
+export function serializeProviderContext(context: unknown, options: ProviderContextSerializationOptions = {}): string {
+	const contextObject = (context ?? {}) as any;
+	const toolOptions: ProviderToolResultSerializationOptions = {
+		...providerToolResultSerializationOptionsFromEnv(),
+		...options,
+	};
+	const includeSystemPrompt = options.includeSystemPrompt ?? true;
+	const systemPrompt = options.systemPrompt ?? contextObject.systemPrompt;
+	const messages = options.messages ?? contextObject.messages ?? [];
+	const taskLines = options.taskLines ?? [
+		"You are being called from Pi through the Cursor SDK Composer 2.5 provider wrapper.",
+		"Respond to the latest user request. If you modify files, summarize the exact changes and verification.",
+	];
+	const lines: string[] = [];
+	if (includeSystemPrompt && systemPrompt) {
+		lines.push("# Pi system prompt", String(systemPrompt), "");
+	}
+	lines.push("# Task", ...taskLines, "", options.conversationTitle ?? "# Conversation");
+	for (const message of messages as any[]) {
+		if (message?.role === "toolResult") {
+			lines.push(
+				`## toolResult ${message.toolName ?? "tool"}`,
+				serializeToolResultContent(message.content, toolOptions),
+				"",
+			);
+		} else {
+			lines.push(`## ${message?.role ?? "message"}`, contentToText(message?.content), "");
+		}
+	}
+	return lines.join("\n").trim();
+}

--- a/pi-extension-cursor-composer/context.ts
+++ b/pi-extension-cursor-composer/context.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import type { SDKCustomTool } from "@cursor/sdk";
 
 // Keep provider replay truncation aligned with Pi's normal tool-output truncation defaults.
 // These mirror @earendil-works/pi-coding-agent DEFAULT_MAX_BYTES / DEFAULT_MAX_LINES
@@ -12,8 +13,12 @@ export type ProviderToolResultSerializationOptions = {
 	maxToolResultLines: number;
 };
 
+export const TOOL_RESULT_RECOVERY_TOOL_NAME = "pi_get_truncated_tool_result";
+
 export type TruncatedToolResultMetadata = {
 	toolName: string;
+	toolCallId?: string;
+	recoveryId?: string;
 	originalBytes: number;
 	originalLines: number;
 	previewBytes: number;
@@ -22,8 +27,19 @@ export type TruncatedToolResultMetadata = {
 	sha256: string;
 };
 
+export type ToolResultRecoveryRecord = {
+	id: string;
+	toolName: string;
+	toolCallId?: string;
+	text: string;
+	originalBytes: number;
+	originalLines: number;
+	sha256: string;
+};
+
 export type ProviderContextSerializationMetadata = {
 	truncatedToolResults: TruncatedToolResultMetadata[];
+	toolResultRecoveryRecords: ToolResultRecoveryRecord[];
 };
 
 export type ProviderContextSerializationResult = {
@@ -37,6 +53,8 @@ export type ProviderContextSerializationOptions = Partial<ProviderToolResultSeri
 	messages?: unknown[];
 	taskLines?: string[];
 	conversationTitle?: string;
+	enableToolResultRecovery?: boolean;
+	recoveryIdFactory?: () => string;
 };
 
 type TextPreview = {
@@ -70,6 +88,11 @@ function lineCount(text: string): number {
 
 function sha256(text: string): string {
 	return createHash("sha256").update(text).digest("hex");
+}
+
+export function deterministicToolResultRecoveryId(toolName: string, toolCallId: string | undefined, contentSha256: string): string {
+	const stableIdentity = JSON.stringify({ toolName, toolCallId: toolCallId ?? null, contentSha256 });
+	return `ptr_${createHash("sha256").update(stableIdentity).digest("hex").slice(0, 24)}`;
 }
 
 function formatBytes(bytes: number): string {
@@ -218,15 +241,28 @@ export function previewTextByBytesAndLines(
 export function serializeToolResultContent(
 	content: unknown,
 	options: ProviderToolResultSerializationOptions,
-	metadata?: { toolName?: string; truncatedToolResults?: TruncatedToolResultMetadata[] },
+	metadata?: {
+		toolName?: string;
+		toolCallId?: string;
+		truncatedToolResults?: TruncatedToolResultMetadata[];
+		toolResultRecoveryRecords?: ToolResultRecoveryRecord[];
+		enableToolResultRecovery?: boolean;
+		recoveryIdFactory?: () => string;
+	},
 ): string {
 	const text = contentToText(content);
 	if (!options.truncateToolResults) return text;
 	const preview = previewTextByBytesAndLines(text, options.maxToolResultBytes, options.maxToolResultLines);
 	if (!preview.truncated) return text;
 	const toolName = metadata?.toolName ?? "tool";
+	const recoveryEnabled = (metadata?.enableToolResultRecovery ?? true) && Boolean(metadata?.toolResultRecoveryRecords);
+	const recoveryId = recoveryEnabled
+		? (metadata?.recoveryIdFactory ?? (() => deterministicToolResultRecoveryId(toolName, metadata?.toolCallId, preview.sha256)))()
+		: undefined;
 	metadata?.truncatedToolResults?.push({
 		toolName,
+		toolCallId: metadata?.toolCallId,
+		recoveryId,
 		originalBytes: preview.originalBytes,
 		originalLines: preview.originalLines,
 		previewBytes: preview.previewBytes,
@@ -234,14 +270,33 @@ export function serializeToolResultContent(
 		omittedBytes: Math.max(0, preview.originalBytes - preview.previewBytes),
 		sha256: preview.sha256,
 	});
+	if (recoveryId) {
+		metadata?.toolResultRecoveryRecords?.push({
+			id: recoveryId,
+			toolName,
+			toolCallId: metadata?.toolCallId,
+			text,
+			originalBytes: preview.originalBytes,
+			originalLines: preview.originalLines,
+			sha256: preview.sha256,
+		});
+	}
 	return [
 		"[Large tool result truncated by Pi Cursor provider wrapper]",
 		`Tool: ${toolName}.`,
+		...(metadata?.toolCallId ? [`Tool call ID: ${metadata.toolCallId}.`] : []),
+		...(recoveryId ? [`Recovery ID: ${recoveryId}.`] : []),
 		`Original: ${preview.originalLines} lines, ${formatBytes(preview.originalBytes)}.`,
 		`Included preview: ${preview.previewLines} lines, ${formatBytes(preview.previewBytes)}.`,
 		`Original SHA-256: ${preview.sha256}.`,
 		"Reason: avoid resending very large prior Pi tool outputs to Cursor Composer on every provider turn.",
-		"If exact historical content is required, disable CURSOR_COMPOSER_PROVIDER_TRUNCATE_TOOL_RESULTS or use available tools to re-read/rerun when safe and equivalent.",
+		...(recoveryId
+			? [
+				`If exact historical content is required, call the Cursor local tool ${TOOL_RESULT_RECOVERY_TOOL_NAME} with this Recovery ID and an optional line range.`,
+			]
+			: [
+				"If exact historical content is required, disable CURSOR_COMPOSER_PROVIDER_TRUNCATE_TOOL_RESULTS or use available tools to re-read/rerun when safe and equivalent.",
+			]),
 		"",
 		"<tool_result_preview_head>",
 		preview.headText,
@@ -250,6 +305,143 @@ export function serializeToolResultContent(
 			? ["", "<tool_result_preview_tail>", preview.tailText, "</tool_result_preview_tail>"]
 			: []),
 	].join("\n");
+}
+
+function integerArg(value: unknown, fallback: number): number {
+	const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+	if (!Number.isFinite(parsed)) return fallback;
+	return Math.floor(parsed);
+}
+
+function lineSegmentsPreservingEndings(text: string): string[] {
+	if (!text) return [];
+	const segments: string[] = [];
+	let start = 0;
+	for (let index = 0; index < text.length; index += 1) {
+		const char = text[index];
+		if (char !== "\r" && char !== "\n") continue;
+		if (char === "\r" && text[index + 1] === "\n") index += 1;
+		segments.push(text.slice(start, index + 1));
+		start = index + 1;
+	}
+	if (start < text.length) {
+		segments.push(text.slice(start));
+	} else if (text.length > 0) {
+		segments.push("");
+	}
+	return segments;
+}
+
+export function readToolResultRecoveryRecord(
+	records: ToolResultRecoveryRecord[],
+	args: Record<string, unknown>,
+	options: { defaultLineCount?: number; maxLineCount?: number; maxBytes?: number } = {},
+): {
+	content: Array<{ type: "text"; text: string }>;
+	isError?: boolean;
+	structuredContent: Record<string, string | number | boolean | null>;
+} {
+	const id = typeof args.id === "string" ? args.id : typeof args.recoveryId === "string" ? args.recoveryId : "";
+	const record = records.find((candidate) => candidate.id === id);
+	if (!record) {
+		return {
+			content: [{ type: "text", text: `No truncated Pi tool result found for recovery ID: ${id || "<missing>"}` }],
+			isError: true,
+			structuredContent: { id: id || null, found: false },
+		};
+	}
+
+	const defaultLineCount = Math.max(1, options.defaultLineCount ?? 200);
+	const maxLineCount = Math.max(1, options.maxLineCount ?? DEFAULT_PROVIDER_TOOL_RESULT_MAX_LINES);
+	const maxBytes = Math.max(1, options.maxBytes ?? DEFAULT_PROVIDER_TOOL_RESULT_MAX_BYTES);
+	const lines = lineSegmentsPreservingEndings(record.text);
+	const requestedStartLine = Math.max(1, integerArg(args.startLine, 1));
+	const requestedLineCount = Math.max(1, integerArg(args.lineCount, defaultLineCount));
+	const returnedLineCount = Math.min(requestedLineCount, maxLineCount);
+	if (requestedStartLine > record.originalLines) {
+		return {
+			content: [
+				{
+					type: "text",
+					text: `Recovery ID ${record.id} has ${record.originalLines} lines; requested startLine ${requestedStartLine} is past the end of the output.`,
+				},
+			],
+			isError: true,
+			structuredContent: {
+				id: record.id,
+				found: true,
+				toolName: record.toolName,
+				toolCallId: record.toolCallId ?? null,
+				sha256: record.sha256,
+				originalBytes: record.originalBytes,
+				originalLines: record.originalLines,
+				startLine: requestedStartLine,
+				endLine: record.originalLines,
+				returnedBytes: 0,
+				truncatedByBytes: false,
+				hasMore: false,
+			},
+		};
+	}
+	const startIndex = requestedStartLine - 1;
+	const endIndex = Math.min(lines.length, startIndex + returnedLineCount);
+	let text = lines.slice(startIndex, endIndex).join("");
+	let truncatedByBytes = false;
+	if (byteLength(text) > maxBytes) {
+		text = clipTextToBytes(text, maxBytes);
+		truncatedByBytes = true;
+	}
+	const actualStartLine = startIndex + 1;
+	const actualEndLine = endIndex;
+	const header = [
+		`Recovered exact Pi tool result slice for ${record.toolName}.`,
+		`Recovery ID: ${record.id}.`,
+		...(record.toolCallId ? [`Tool call ID: ${record.toolCallId}.`] : []),
+		`Original: ${record.originalLines} lines, ${formatBytes(record.originalBytes)}, SHA-256 ${record.sha256}.`,
+		`Returned lines ${actualStartLine}-${actualEndLine}${truncatedByBytes ? `, clipped to ${formatBytes(maxBytes)}` : ""}.`,
+		endIndex < record.originalLines || truncatedByBytes ? "Request a later startLine or smaller lineCount for more exact content." : "End of recovered output.",
+	].join("\n");
+
+	return {
+		content: [{ type: "text", text: `${header}\n\n<recovered_tool_result>\n${text}\n</recovered_tool_result>` }],
+		structuredContent: {
+			id: record.id,
+			found: true,
+			toolName: record.toolName,
+			toolCallId: record.toolCallId ?? null,
+			sha256: record.sha256,
+			originalBytes: record.originalBytes,
+			originalLines: record.originalLines,
+			startLine: actualStartLine,
+			endLine: actualEndLine,
+			returnedBytes: byteLength(text),
+			truncatedByBytes,
+			hasMore: endIndex < record.originalLines || truncatedByBytes,
+		},
+	};
+}
+
+export function createToolResultRecoveryCustomTools(
+	records: ToolResultRecoveryRecord[],
+	options: { defaultLineCount?: number; maxLineCount?: number; maxBytes?: number } = {},
+): Record<string, SDKCustomTool> | undefined {
+	if (records.length === 0) return undefined;
+	return {
+		[TOOL_RESULT_RECOVERY_TOOL_NAME]: {
+			description:
+				"Fetch an exact slice of a large historical Pi tool result that was truncated in the Cursor Composer provider prompt. Use the Recovery ID shown in the truncation marker.",
+			inputSchema: {
+				type: "object",
+				properties: {
+					id: { type: "string", description: "Recovery ID from the truncated Pi tool-result marker." },
+					startLine: { type: "number", description: "1-based first line to return. Defaults to 1." },
+					lineCount: { type: "number", description: "Number of lines to return. Defaults to 200 and is capped." },
+				},
+				required: ["id"],
+			},
+			execute: (args: Record<string, unknown>) => readToolResultRecoveryRecord(records, args, options),
+		},
+	};
 }
 
 export function serializeProviderContextWithMetadata(
@@ -261,7 +453,7 @@ export function serializeProviderContextWithMetadata(
 		...providerToolResultSerializationOptionsFromEnv(),
 		...options,
 	};
-	const metadata: ProviderContextSerializationMetadata = { truncatedToolResults: [] };
+	const metadata: ProviderContextSerializationMetadata = { truncatedToolResults: [], toolResultRecoveryRecords: [] };
 	const includeSystemPrompt = options.includeSystemPrompt ?? true;
 	const systemPrompt = options.systemPrompt ?? contextObject.systemPrompt;
 	const messages = options.messages ?? contextObject.messages ?? [];
@@ -281,7 +473,11 @@ export function serializeProviderContextWithMetadata(
 				`## toolResult ${toolName}`,
 				serializeToolResultContent(message.content, toolOptions, {
 					toolName,
+					toolCallId: typeof message.toolCallId === "string" ? message.toolCallId : undefined,
 					truncatedToolResults: metadata.truncatedToolResults,
+					toolResultRecoveryRecords: metadata.toolResultRecoveryRecords,
+					enableToolResultRecovery: options.enableToolResultRecovery,
+					recoveryIdFactory: options.recoveryIdFactory,
 				}),
 				"",
 			);

--- a/pi-extension-cursor-composer/index.ts
+++ b/pi-extension-cursor-composer/index.ts
@@ -17,6 +17,7 @@ import {
 	type ExtensionAPI,
 } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
+import { serializeProviderContext } from "./context.ts";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
@@ -652,43 +653,6 @@ async function runCursorComposer(options: RunCursorComposerOptions): Promise<Cur
 	}
 }
 
-function contentToText(content: unknown): string {
-	if (typeof content === "string") return content;
-	if (!Array.isArray(content)) return normalizeText(content);
-	return content
-		.map((block: any) => {
-			if (block?.type === "text") return block.text ?? "";
-			if (block?.type === "thinking") return `[thinking]\n${block.thinking ?? ""}`;
-			if (block?.type === "toolCall") return `[tool call: ${block.name ?? "unknown"}]\n${normalizeText(block.arguments)}`;
-			if (block?.type === "image") return "[image omitted by Pi Cursor provider wrapper]";
-			return normalizeText(block);
-		})
-		.filter(Boolean)
-		.join("\n");
-}
-
-function serializeProviderContext(context: Context): string {
-	const lines: string[] = [];
-	if ((context as any).systemPrompt) {
-		lines.push("# Pi system prompt", String((context as any).systemPrompt), "");
-	}
-	lines.push(
-		"# Task",
-		"You are being called from Pi through the Cursor SDK Composer 2.5 provider wrapper.",
-		"Respond to the latest user request. If you modify files, summarize the exact changes and verification.",
-		"",
-		"# Conversation",
-	);
-	for (const message of ((context as any).messages ?? []) as any[]) {
-		if (message.role === "toolResult") {
-			lines.push(`## toolResult ${message.toolName ?? "tool"}`, contentToText(message.content), "");
-		} else {
-			lines.push(`## ${message.role ?? "message"}`, contentToText(message.content), "");
-		}
-	}
-	return lines.join("\n").trim();
-}
-
 function thinkingFromProviderOptions(options?: SimpleStreamOptions): Thinking | undefined {
 	const value = options?.reasoning;
 	if (value === "medium" || value === "high") return value;
@@ -728,6 +692,7 @@ function streamCursorComposerProvider(
 	const stream = createAssistantMessageEventStream();
 
 	(async () => {
+		const thinking = thinkingFromProviderOptions(options);
 		const promptText = serializeProviderContext(context);
 		const output: AssistantMessage = {
 			role: "assistant",
@@ -817,7 +782,7 @@ function streamCursorComposerProvider(
 				cwd: process.cwd(),
 				apiKey,
 				mode: "agent",
-				thinking: thinkingFromProviderOptions(options),
+				thinking,
 				autoReview: providerAutoReview(),
 				sandbox: providerSandbox(),
 				signal: options?.signal,
@@ -1004,7 +969,7 @@ export default function cursorComposerExtension(pi: ExtensionAPI): void {
 				sdkStatus = error instanceof Error ? error.message : String(error);
 			}
 			ctx.ui.notify(
-				`${ENV_KEY}: ${key.apiKey ? `configured via ${key.source}${key.path ? ` (${key.path})` : ""}` : "missing"}\n@cursor/sdk: ${sdkStatus}\nPi provider: ${PI_MODEL_REF}\nPricing: ${describeCursorComposerPricing()}\nContext: ${CURSOR_COMPOSER_CONTEXT_WINDOW.toLocaleString()} tokens\nScoped models: ${scopedStatus}`,
+				`${ENV_KEY}: ${key.apiKey ? `configured via ${key.source}${key.path ? ` (${key.path})` : ""}` : "missing"}\n@cursor/sdk: ${sdkStatus}\nPi provider: ${PI_MODEL_REF}\nPricing: ${describeCursorComposerPricing()}\nContext: ${CURSOR_COMPOSER_CONTEXT_WINDOW.toLocaleString()} tokens\nTool-result truncation: ${process.env.CURSOR_COMPOSER_PROVIDER_TRUNCATE_TOOL_RESULTS === "false" ? "off" : "on"}\nScoped models: ${scopedStatus}`,
 				key.apiKey && sdkStatus === "installed" ? "info" : "warning",
 			);
 		},

--- a/pi-extension-cursor-composer/index.ts
+++ b/pi-extension-cursor-composer/index.ts
@@ -17,7 +17,11 @@ import {
 	type ExtensionAPI,
 } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
-import { serializeProviderContext } from "./context.ts";
+import {
+	providerToolResultSerializationOptionsFromEnv,
+	serializeProviderContextWithMetadata,
+	type ProviderContextSerializationMetadata,
+} from "./context.ts";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
@@ -661,6 +665,17 @@ function thinkingFromProviderOptions(options?: SimpleStreamOptions): Thinking | 
 	return undefined;
 }
 
+function summarizeProviderContextTruncation(metadata: ProviderContextSerializationMetadata): string | undefined {
+	const truncated = metadata.truncatedToolResults;
+	if (truncated.length === 0) return undefined;
+	const originalBytes = truncated.reduce((total, item) => total + item.originalBytes, 0);
+	const previewBytes = truncated.reduce((total, item) => total + item.previewBytes, 0);
+	const omittedBytes = truncated.reduce((total, item) => total + item.omittedBytes, 0);
+	const toolNames = Array.from(new Set(truncated.map((item) => item.toolName))).slice(0, 4).join(", ");
+	const toolSuffix = toolNames ? ` (${toolNames}${truncated.length > 4 ? ", …" : ""})` : "";
+	return `Pi Cursor provider truncated ${truncated.length} prior tool result${truncated.length === 1 ? "" : "s"}${toolSuffix}: sent ${formatSize(previewBytes)} of ${formatSize(originalBytes)}, omitted ${formatSize(omittedBytes)}. Re-read/rerun if exact omitted content is needed.`;
+}
+
 function providerAutoReview(): boolean {
 	return process.env.CURSOR_COMPOSER_PROVIDER_AUTO_REVIEW !== "false";
 }
@@ -693,7 +708,12 @@ function streamCursorComposerProvider(
 
 	(async () => {
 		const thinking = thinkingFromProviderOptions(options);
-		const promptText = serializeProviderContext(context);
+		const serializedContext = serializeProviderContextWithMetadata(context, {
+			maxToolResultBytes: DEFAULT_MAX_BYTES,
+			maxToolResultLines: DEFAULT_MAX_LINES,
+		});
+		const promptText = serializedContext.prompt;
+		const truncationSummary = summarizeProviderContextTruncation(serializedContext.metadata);
 		const output: AssistantMessage = {
 			role: "assistant",
 			content: [],
@@ -774,6 +794,20 @@ function streamCursorComposerProvider(
 		try {
 			stream.push({ type: "start", partial: output });
 			startHeartbeat();
+			if (truncationSummary) {
+				pushProviderStatus(truncationSummary);
+				output.diagnostics = [
+					...(output.diagnostics ?? []),
+					{
+						type: "cursor-composer.provider_context_truncated",
+						timestamp: Date.now(),
+						details: {
+							summary: truncationSummary,
+							truncatedToolResults: serializedContext.metadata.truncatedToolResults,
+						},
+					},
+				];
+			}
 			const apiKey = options?.apiKey ?? resolveApiKey(process.cwd()).apiKey;
 			if (!apiKey) throw new Error(`${ENV_KEY} is missing. Run /cursor-composer-setup first.`);
 
@@ -968,8 +1002,15 @@ export default function cursorComposerExtension(pi: ExtensionAPI): void {
 			} catch (error) {
 				sdkStatus = error instanceof Error ? error.message : String(error);
 			}
+			const truncation = providerToolResultSerializationOptionsFromEnv(process.env, {
+				maxToolResultBytes: DEFAULT_MAX_BYTES,
+				maxToolResultLines: DEFAULT_MAX_LINES,
+			});
+			const truncationStatus = truncation.truncateToolResults
+				? `on (${formatSize(truncation.maxToolResultBytes)}, ${truncation.maxToolResultLines.toLocaleString()} lines)`
+				: "off";
 			ctx.ui.notify(
-				`${ENV_KEY}: ${key.apiKey ? `configured via ${key.source}${key.path ? ` (${key.path})` : ""}` : "missing"}\n@cursor/sdk: ${sdkStatus}\nPi provider: ${PI_MODEL_REF}\nPricing: ${describeCursorComposerPricing()}\nContext: ${CURSOR_COMPOSER_CONTEXT_WINDOW.toLocaleString()} tokens\nTool-result truncation: ${process.env.CURSOR_COMPOSER_PROVIDER_TRUNCATE_TOOL_RESULTS === "false" ? "off" : "on"}\nScoped models: ${scopedStatus}`,
+				`${ENV_KEY}: ${key.apiKey ? `configured via ${key.source}${key.path ? ` (${key.path})` : ""}` : "missing"}\n@cursor/sdk: ${sdkStatus}\nPi provider: ${PI_MODEL_REF}\nPricing: ${describeCursorComposerPricing()}\nContext: ${CURSOR_COMPOSER_CONTEXT_WINDOW.toLocaleString()} tokens\nTool-result truncation: ${truncationStatus}\nScoped models: ${scopedStatus}`,
 				key.apiKey && sdkStatus === "installed" ? "info" : "warning",
 			);
 		},

--- a/pi-extension-cursor-composer/index.ts
+++ b/pi-extension-cursor-composer/index.ts
@@ -18,9 +18,12 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import {
+	TOOL_RESULT_RECOVERY_TOOL_NAME,
+	createToolResultRecoveryCustomTools,
 	providerToolResultSerializationOptionsFromEnv,
 	serializeProviderContextWithMetadata,
 	type ProviderContextSerializationMetadata,
+	type ToolResultRecoveryRecord,
 } from "./context.ts";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -76,6 +79,7 @@ type RunCursorComposerOptions = {
 	onStatus?: (message: string) => void;
 	onTextDelta?: (delta: string, accumulated: string) => void;
 	onUsage?: (usage: CursorComposerUsage) => void;
+	toolResultRecoveryRecords?: ToolResultRecoveryRecord[];
 };
 
 type CursorComposerResult = {
@@ -513,12 +517,21 @@ function shouldForwardProviderStatus(message: string): boolean {
 	return false;
 }
 
+function cursorConversationErrorSummary(conversation: unknown): unknown {
+	if (conversation === undefined) return undefined;
+	if (Array.isArray(conversation)) return { type: "array", items: conversation.length };
+	if (conversation && typeof conversation === "object") {
+		return { type: "object", keys: Object.keys(conversation as Record<string, unknown>).slice(0, 12) };
+	}
+	return { type: typeof conversation };
+}
+
 function cursorRunErrorMessage(result: any, run: any, conversation?: unknown): string {
 	const requestId = result?.requestId ?? run?.requestId;
 	const parts = ["Cursor Composer run failed"];
 	if (requestId) parts.push(`requestId=${requestId}`);
-	if (result?.result) parts.push(String(result.result));
-	parts.push(compactJson({ status: result?.status, model: result?.model, git: result?.git, conversation }));
+	if (result?.result) parts.push(truncateForTool(String(result.result)).text);
+	parts.push(compactJson({ status: result?.status, model: result?.model, git: result?.git, conversation: cursorConversationErrorSummary(conversation) }));
 	return parts.filter(Boolean).join(" — ");
 }
 
@@ -573,7 +586,14 @@ async function runCursorComposer(options: RunCursorComposerOptions): Promise<Cur
 	};
 
 	try {
+		const recoveryTools = createToolResultRecoveryCustomTools(options.toolResultRecoveryRecords ?? [], {
+			maxBytes: DEFAULT_MAX_BYTES,
+			maxLineCount: DEFAULT_MAX_LINES,
+		});
 		options.onStatus?.(`Creating Cursor local agent in ${options.cwd}`);
+		if (recoveryTools) {
+			options.onStatus?.(`Registered ${TOOL_RESULT_RECOVERY_TOOL_NAME} for exact truncated Pi tool-result recovery`);
+		}
 		agent = await Agent.create({
 			apiKey: options.apiKey,
 			model,
@@ -582,6 +602,7 @@ async function runCursorComposer(options: RunCursorComposerOptions): Promise<Cur
 				cwd: options.cwd,
 				autoReview: options.autoReview,
 				sandboxOptions: { enabled: options.sandbox },
+				...(recoveryTools ? { customTools: recoveryTools } : {}),
 			},
 		});
 
@@ -673,7 +694,9 @@ function summarizeProviderContextTruncation(metadata: ProviderContextSerializati
 	const omittedBytes = truncated.reduce((total, item) => total + item.omittedBytes, 0);
 	const toolNames = Array.from(new Set(truncated.map((item) => item.toolName))).slice(0, 4).join(", ");
 	const toolSuffix = toolNames ? ` (${toolNames}${truncated.length > 4 ? ", …" : ""})` : "";
-	return `Pi Cursor provider truncated ${truncated.length} prior tool result${truncated.length === 1 ? "" : "s"}${toolSuffix}: sent ${formatSize(previewBytes)} of ${formatSize(originalBytes)}, omitted ${formatSize(omittedBytes)}. Re-read/rerun if exact omitted content is needed.`;
+	const recoverableCount = truncated.filter((item) => item.recoveryId).length;
+	const recoverySuffix = recoverableCount > 0 ? ` ${recoverableCount} recoverable through ${TOOL_RESULT_RECOVERY_TOOL_NAME}.` : "";
+	return `Pi Cursor provider truncated ${truncated.length} prior tool result${truncated.length === 1 ? "" : "s"}${toolSuffix}: sent ${formatSize(previewBytes)} of ${formatSize(originalBytes)}, omitted ${formatSize(omittedBytes)}.${recoverySuffix}`;
 }
 
 function providerAutoReview(): boolean {
@@ -713,6 +736,7 @@ function streamCursorComposerProvider(
 			maxToolResultLines: DEFAULT_MAX_LINES,
 		});
 		const promptText = serializedContext.prompt;
+		const toolResultRecoveryRecords = serializedContext.metadata.toolResultRecoveryRecords;
 		const truncationSummary = summarizeProviderContextTruncation(serializedContext.metadata);
 		const output: AssistantMessage = {
 			role: "assistant",
@@ -823,6 +847,7 @@ function streamCursorComposerProvider(
 				onStatus: pushProviderStatus,
 				onTextDelta: (delta) => pushText(delta),
 				onUsage: applyCursorUsage,
+				toolResultRecoveryRecords,
 			});
 
 			if (result.status === "cancelled") throw new Error("Cursor Composer run cancelled.");

--- a/pi-extension-cursor-composer/package-lock.json
+++ b/pi-extension-cursor-composer/package-lock.json
@@ -1,0 +1,755 @@
+{
+  "name": "@firstpick/pi-extension-cursor-composer",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@firstpick/pi-extension-cursor-composer",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@connectrpc/connect-node": "^1.7.0",
+        "@cursor/sdk": "^1.0.16"
+      },
+      "devDependencies": {
+        "tsx": "^4.20.6"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-ai": "*",
+        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*",
+        "typebox": "*"
+      },
+      "peerDependenciesMeta": {
+        "@earendil-works/pi-ai": {
+          "optional": true
+        },
+        "@earendil-works/pi-coding-agent": {
+          "optional": true
+        },
+        "@earendil-works/pi-tui": {
+          "optional": true
+        },
+        "typebox": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.7.0.tgz",
+      "integrity": "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-1.7.0.tgz",
+      "integrity": "sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      }
+    },
+    "node_modules/@cursor/sdk": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.19.tgz",
+      "integrity": "sha512-DJbVnGeRJq7iwt9mz1cMACqVfAYP15IB+Q8Iz2eDtEN4A8Dp83yB0Y31YREj1jeA9EPUEdRZJRIYch/s+Wi9Ow==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@bufbuild/protobuf": "1.10.0",
+        "@connectrpc/connect": "^1.6.1",
+        "@connectrpc/connect-web": "^1.6.1",
+        "@statsig/js-client": "3.31.0",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "optionalDependencies": {
+        "@cursor/sdk-darwin-arm64": "1.0.19",
+        "@cursor/sdk-darwin-x64": "1.0.19",
+        "@cursor/sdk-linux-arm64": "1.0.19",
+        "@cursor/sdk-linux-x64": "1.0.19",
+        "@cursor/sdk-win32-x64": "1.0.19"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-arm64": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.19.tgz",
+      "integrity": "sha512-CPhqcpDaqjjqkkVGMLsdfXv7PGznL5L6U5CJXps/oaGW5mtHoxDpsRNj1rszCRQXNAvmMU+EFxLWnBwlE8mUNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-x64": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.19.tgz",
+      "integrity": "sha512-6/Jj0hxrxEs9V9wtYEApSkMcJwYAaT4Vwna9xBzgN6CK1K4Ws0E1/PfiddahAAFZpkp9pgjb8wQXwG7qJ2g77A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-linux-arm64": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.19.tgz",
+      "integrity": "sha512-Dq/BhGT1jAZ6eHJwy1Vugi/Upc+yoL0X/LN6ppd9cVPM9OAB1xX5KIbvIwsGlNiZccPLVXFv/1KOp5SBK+y+jQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-linux-x64": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.19.tgz",
+      "integrity": "sha512-ZHgHH+SdEwYwfPg/uVKqZRVOIMCV3/3vghxc/usOMYMrhbY9TYXZxYqwWTduVLzCXH7Dz0aT19mSJHmhwkQ1CA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-win32-x64": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.19.tgz",
+      "integrity": "sha512-XGIQmx3J0K8uKkA00qnoy1FJHFdFdwNdcmUqtRF1PXLcYup91YYetAHk9afXM7S/v1t0L4EatydsirL8uz7SIw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "rg": "bin/rg.exe"
+      }
+    },
+    "node_modules/@cursor/sdk/node_modules/@bufbuild/protobuf": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
+      "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@statsig/client-core": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.31.0.tgz",
+      "integrity": "sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==",
+      "license": "ISC"
+    },
+    "node_modules/@statsig/js-client": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/js-client/-/js-client-3.31.0.tgz",
+      "integrity": "sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==",
+      "license": "ISC",
+      "dependencies": {
+        "@statsig/client-core": "3.31.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/pi-extension-cursor-composer/package.json
+++ b/pi-extension-cursor-composer/package.json
@@ -22,9 +22,17 @@
       "./index.ts"
     ]
   },
+  "scripts": {
+    "test": "node --import tsx --test tests/*.test.ts",
+    "smoke:cursor": "node --import tsx scripts/cursor-usage-smoke.ts",
+    "benchmark:cursor": "node --import tsx scripts/cursor-truncation-benchmark.ts"
+  },
   "dependencies": {
     "@connectrpc/connect-node": "^1.7.0",
     "@cursor/sdk": "^1.0.16"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.6"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
@@ -48,6 +56,7 @@
   },
   "files": [
     "index.ts",
+    "context.ts",
     "README.md",
     "LICENSE"
   ]

--- a/pi-extension-cursor-composer/scripts/cursor-truncation-benchmark.ts
+++ b/pi-extension-cursor-composer/scripts/cursor-truncation-benchmark.ts
@@ -1,0 +1,328 @@
+import { Agent } from "@cursor/sdk";
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { serializeProviderContext } from "../context.ts";
+
+const MODEL_ID = "composer-2.5";
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_DIR = resolve(SCRIPT_DIR, "..");
+const OUTPUT_DIR = join(PACKAGE_DIR, "benchmark-output");
+const TURN_COUNT = Math.min(10, Math.max(1, Number(process.env.CURSOR_COMPOSER_BENCHMARK_TURNS ?? 10)));
+const TOOL_RESULT_TARGET_BYTES = Math.max(12_000, Number(process.env.CURSOR_COMPOSER_BENCHMARK_TOOL_BYTES ?? 32_000));
+
+type Usage = {
+	inputTokens?: number;
+	outputTokens?: number;
+	cacheReadTokens?: number;
+	cacheWriteTokens?: number;
+};
+
+type BenchmarkTask = {
+	id: string;
+	prompt: string;
+	expectedEvidence: string[];
+};
+
+type TurnRecord = {
+	variant: "original" | "optimized";
+	turn: number;
+	taskId: string;
+	promptBytes: number;
+	usage?: Usage;
+	totalUsage: number;
+	status?: string;
+	durationMs: number;
+	result: string;
+	resultChars: number;
+	eventTypes: Record<string, number>;
+	toolLikeEvents: number;
+	quality: {
+		nonEmpty: boolean;
+		mentionsExpectedEvidence: boolean;
+		refusalOrUnable: boolean;
+		jsonLike: boolean;
+	};
+};
+
+const TASKS: BenchmarkTask[] = [
+	{
+		id: "purpose",
+		prompt: "Inspect the local package files if needed. Explain this Pi extension's purpose and name the provider/model it registers. Return compact JSON with keys answer, evidenceFiles, and confidence.",
+		expectedEvidence: ["README.md", "package.json"],
+	},
+	{
+		id: "commands",
+		prompt: "Inspect index.ts or README.md. List the registered slash commands exposed by this extension. Return compact JSON with keys answer, evidenceFiles, and confidence.",
+		expectedEvidence: ["index.ts", "README.md"],
+	},
+	{
+		id: "tool-truncation-default",
+		prompt: "Inspect context.ts. What happens to a large Pi toolResult by default, and what metadata is preserved? Return compact JSON with keys answer, evidenceFiles, and confidence.",
+		expectedEvidence: ["context.ts"],
+	},
+	{
+		id: "truncation-env",
+		prompt: "Inspect context.ts and README.md. Which environment variables control provider tool-result truncation? Return compact JSON with keys answer, evidenceFiles, and confidence.",
+		expectedEvidence: ["context.ts", "README.md"],
+	},
+	{
+		id: "provider-usage",
+		prompt: "Inspect index.ts. How does the provider report Cursor SDK token usage back to Pi? Return compact JSON with keys answer, evidenceFiles, and confidence.",
+		expectedEvidence: ["index.ts"],
+	},
+	{
+		id: "pricing",
+		prompt: "Inspect index.ts and README.md. Summarize the default Composer 2.5 pricing tier and override variables. Return compact JSON with keys answer, evidenceFiles, and confidence.",
+		expectedEvidence: ["index.ts", "README.md"],
+	},
+	{
+		id: "heartbeat",
+		prompt: "Inspect index.ts and README.md. Explain provider heartbeat/verbosity behavior. Return compact JSON with keys answer, evidenceFiles, and confidence.",
+		expectedEvidence: ["index.ts", "README.md"],
+	},
+	{
+		id: "tests",
+		prompt: "Inspect package.json and tests. What offline tests exist for truncation behavior? Return compact JSON with keys answer, evidenceFiles, and confidence.",
+		expectedEvidence: ["package.json", "tests/context-serialization.test.ts"],
+	},
+	{
+		id: "package-files",
+		prompt: "Inspect package.json. Which files are included in the published package and why does context.ts need to be there? Return compact JSON with keys answer, evidenceFiles, and confidence.",
+		expectedEvidence: ["package.json", "context.ts"],
+	},
+	{
+		id: "safety",
+		prompt: "Inspect README.md and index.ts. What safety warnings or defaults matter before letting Cursor Composer run tools or edit files? Return compact JSON with keys answer, evidenceFiles, and confidence.",
+		expectedEvidence: ["README.md", "index.ts"],
+	},
+];
+
+function bytes(text: string): number {
+	return Buffer.byteLength(text, "utf8");
+}
+
+function totalUsage(usage: Usage | undefined): number {
+	if (!usage) return 0;
+	return (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0) + (usage.cacheReadTokens ?? 0) + (usage.cacheWriteTokens ?? 0);
+}
+
+function usageString(usage: Usage | undefined): string {
+	if (!usage) return "usage=none";
+	return `input=${usage.inputTokens ?? 0} output=${usage.outputTokens ?? 0} cacheRead=${usage.cacheReadTokens ?? 0} cacheWrite=${usage.cacheWriteTokens ?? 0} total=${totalUsage(usage)}`;
+}
+
+async function createBenchmarkWorkspace(): Promise<string> {
+	const workspace = mkdtempSync(join(tmpdir(), "cursor-composer-benchmark-"));
+	for (const entry of ["README.md", "index.ts", "context.ts", "package.json", "tests"]) {
+		await cp(join(PACKAGE_DIR, entry), join(workspace, entry), { recursive: true });
+	}
+	return workspace;
+}
+
+async function sourceCorpus(): Promise<string> {
+	const files = ["README.md", "index.ts", "context.ts", "package.json", "tests/context-serialization.test.ts"];
+	const parts: string[] = [];
+	for (const file of files) {
+		const text = await readFile(join(PACKAGE_DIR, file), "utf8");
+		parts.push(`===== ${file} =====\n${text}`);
+	}
+	return parts.join("\n\n");
+}
+
+function makeLargeToolResult(corpus: string, turn: number): string {
+	const header = [
+		`Synthetic Pi prior tool output for benchmark turn ${turn}.`,
+		"This simulates a large read/bash result already present in Pi conversation history.",
+		"The current user request should still be answered by inspecting local files when exact details are needed.",
+		"",
+	].join("\n");
+	let body = header;
+	let pass = 0;
+	while (bytes(body) < TOOL_RESULT_TARGET_BYTES) {
+		body += `\n--- corpus repetition ${pass++} ---\n${corpus.slice(0, 12_000)}\n`;
+	}
+	return body.slice(0, TOOL_RESULT_TARGET_BYTES);
+}
+
+function quality(result: string, expectedEvidence: string[]): TurnRecord["quality"] {
+	const lower = result.toLowerCase();
+	return {
+		nonEmpty: result.trim().length > 20,
+		mentionsExpectedEvidence: expectedEvidence.some((file) => result.includes(file)),
+		refusalOrUnable: /unable|can't access|cannot access|don't have access|i can’t access/i.test(result),
+		jsonLike: result.trim().startsWith("{") || result.includes('"answer"'),
+	};
+}
+
+async function runCursorTurn(workspace: string, prompt: string): Promise<{ result: string; status?: string; usage?: Usage; eventTypes: Record<string, number>; toolLikeEvents: number }> {
+	const apiKey = process.env.CURSOR_API_KEY;
+	if (!apiKey) throw new Error("CURSOR_API_KEY is required for live benchmark");
+	let usage: Usage | undefined;
+	const eventTypes: Record<string, number> = {};
+	let toolLikeEvents = 0;
+	const agent = await Agent.create({
+		apiKey,
+		model: { id: MODEL_ID },
+		mode: "agent",
+		local: {
+			cwd: workspace,
+			autoReview: false,
+			sandboxOptions: { enabled: false },
+		},
+	});
+	try {
+		const run = await agent.send(prompt, {
+			mode: "agent",
+			onDelta: ({ update }: { update: any }) => {
+				const type = String(update?.type ?? "unknown");
+				eventTypes[type] = (eventTypes[type] ?? 0) + 1;
+				const serialized = JSON.stringify(update ?? {}).toLowerCase();
+				if (/tool|read|grep|search|command|file/.test(serialized)) toolLikeEvents++;
+				if (update?.type === "turn-ended" && update.usage) usage = update.usage;
+			},
+		});
+		const result = await run.wait();
+		return {
+			result: String(result?.result ?? ""),
+			status: result?.status,
+			usage,
+			eventTypes,
+			toolLikeEvents,
+		};
+	} finally {
+		await agent[Symbol.asyncDispose]?.();
+		agent.close?.();
+	}
+}
+
+async function runVariant(variant: "original" | "optimized", workspace: string, corpus: string): Promise<TurnRecord[]> {
+	const truncateToolResults = variant === "optimized";
+	const transcript: any[] = [];
+	const records: TurnRecord[] = [];
+	const tasks = TASKS.slice(0, TURN_COUNT);
+	for (let index = 0; index < tasks.length; index++) {
+		const task = tasks[index];
+		const turn = index + 1;
+		const priorToolResult = {
+			role: "toolResult",
+			toolName: "read",
+			content: [{ type: "text", text: makeLargeToolResult(corpus, turn) }],
+		};
+		const user = { role: "user", content: [{ type: "text", text: task.prompt }] };
+		const context = {
+			systemPrompt: [
+				"You are Composer 2.5 running through a Pi provider benchmark.",
+				"Use local workspace inspection tools when useful. Do not modify files. Do not run destructive commands.",
+				"Return compact JSON only, with keys answer, evidenceFiles, and confidence.",
+			].join("\n"),
+			messages: [...transcript, priorToolResult, user],
+		};
+		const prompt = serializeProviderContext(context, {
+			truncateToolResults,
+			maxToolResultBytes: 8_000,
+			maxToolResultLines: 80,
+		});
+		const started = Date.now();
+		const run = await runCursorTurn(workspace, prompt);
+		const record: TurnRecord = {
+			variant,
+			turn,
+			taskId: task.id,
+			promptBytes: bytes(prompt),
+			usage: run.usage,
+			totalUsage: totalUsage(run.usage),
+			status: run.status,
+			durationMs: Date.now() - started,
+			result: run.result,
+			resultChars: run.result.length,
+			eventTypes: run.eventTypes,
+			toolLikeEvents: run.toolLikeEvents,
+			quality: quality(run.result, task.expectedEvidence),
+		};
+		records.push(record);
+		transcript.push(priorToolResult, user, { role: "assistant", content: [{ type: "text", text: run.result }] });
+		console.log(`${variant} turn=${turn} task=${task.id} promptBytes=${record.promptBytes} ${usageString(record.usage)} quality=${JSON.stringify(record.quality)}`);
+	}
+	return records;
+}
+
+function summarize(records: TurnRecord[]) {
+	const totalPromptBytes = records.reduce((sum, record) => sum + record.promptBytes, 0);
+	const totalTokens = records.reduce((sum, record) => sum + record.totalUsage, 0);
+	return {
+		turns: records.length,
+		totalPromptBytes,
+		totalTokens,
+		inputTokens: records.reduce((sum, record) => sum + (record.usage?.inputTokens ?? 0), 0),
+		outputTokens: records.reduce((sum, record) => sum + (record.usage?.outputTokens ?? 0), 0),
+		cacheReadTokens: records.reduce((sum, record) => sum + (record.usage?.cacheReadTokens ?? 0), 0),
+		cacheWriteTokens: records.reduce((sum, record) => sum + (record.usage?.cacheWriteTokens ?? 0), 0),
+		jsonLike: records.filter((record) => record.quality.jsonLike).length,
+		nonEmpty: records.filter((record) => record.quality.nonEmpty).length,
+		mentionsExpectedEvidence: records.filter((record) => record.quality.mentionsExpectedEvidence).length,
+		refusalOrUnable: records.filter((record) => record.quality.refusalOrUnable).length,
+		toolLikeEvents: records.reduce((sum, record) => sum + record.toolLikeEvents, 0),
+	};
+}
+
+async function writeOutputs(original: TurnRecord[], optimized: TurnRecord[]) {
+	await mkdir(OUTPUT_DIR, { recursive: true });
+	const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+	const recordsPath = join(OUTPUT_DIR, `cursor-truncation-benchmark-${stamp}.jsonl`);
+	const summaryPath = join(OUTPUT_DIR, `cursor-truncation-benchmark-${stamp}.summary.json`);
+	const records = [...original, ...optimized];
+	await writeFile(recordsPath, records.map((record) => JSON.stringify(record)).join("\n") + "\n");
+	const originalSummary = summarize(original);
+	const optimizedSummary = summarize(optimized);
+	const summary = {
+		generatedAt: new Date().toISOString(),
+		turns: TURN_COUNT,
+		toolResultTargetBytes: TOOL_RESULT_TARGET_BYTES,
+		original: originalSummary,
+		optimized: optimizedSummary,
+		reductions: {
+			promptBytesPct: Number(((1 - optimizedSummary.totalPromptBytes / originalSummary.totalPromptBytes) * 100).toFixed(1)),
+			totalTokensPct: Number(((1 - optimizedSummary.totalTokens / originalSummary.totalTokens) * 100).toFixed(1)),
+			inputTokensPct: Number(((1 - optimizedSummary.inputTokens / originalSummary.inputTokens) * 100).toFixed(1)),
+		},
+		recordsPath,
+	};
+	await writeFile(summaryPath, JSON.stringify(summary, null, 2));
+	console.log(`recordsPath=${recordsPath}`);
+	console.log(`summaryPath=${summaryPath}`);
+	console.log(JSON.stringify(summary, null, 2));
+}
+
+async function main() {
+	if (!process.argv.includes("--live") && process.env.CURSOR_COMPOSER_LIVE_BENCHMARK !== "true") {
+		console.log("Dry run only. Set CURSOR_COMPOSER_LIVE_BENCHMARK=true or pass --live to call Cursor.");
+		const corpus = await sourceCorpus();
+		const originalPrompt = serializeProviderContext({ systemPrompt: "dry", messages: [{ role: "toolResult", toolName: "read", content: [{ type: "text", text: makeLargeToolResult(corpus, 1) }] }] }, { truncateToolResults: false });
+		const optimizedPrompt = serializeProviderContext({ systemPrompt: "dry", messages: [{ role: "toolResult", toolName: "read", content: [{ type: "text", text: makeLargeToolResult(corpus, 1) }] }] }, { truncateToolResults: true, maxToolResultBytes: 8_000, maxToolResultLines: 80 });
+		console.log(`dryOriginalPromptBytes=${bytes(originalPrompt)}`);
+		console.log(`dryOptimizedPromptBytes=${bytes(optimizedPrompt)}`);
+		console.log(`dryReduction=${((1 - bytes(optimizedPrompt) / bytes(originalPrompt)) * 100).toFixed(1)}%`);
+		return;
+	}
+	const corpus = await sourceCorpus();
+	const workspace = await createBenchmarkWorkspace();
+	try {
+		console.log(`benchmarkWorkspace=${workspace}`);
+		console.log(`turns=${TURN_COUNT} toolResultTargetBytes=${TOOL_RESULT_TARGET_BYTES}`);
+		const original = await runVariant("original", workspace, corpus);
+		const optimized = await runVariant("optimized", workspace, corpus);
+		await writeOutputs(original, optimized);
+	} finally {
+		if (process.env.CURSOR_COMPOSER_KEEP_BENCHMARK_WORKSPACE !== "true") {
+			await rm(workspace, { recursive: true, force: true });
+		}
+	}
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exitCode = 1;
+});

--- a/pi-extension-cursor-composer/scripts/cursor-truncation-benchmark.ts
+++ b/pi-extension-cursor-composer/scripts/cursor-truncation-benchmark.ts
@@ -12,6 +12,7 @@ const PACKAGE_DIR = resolve(SCRIPT_DIR, "..");
 const OUTPUT_DIR = join(PACKAGE_DIR, "benchmark-output");
 const TURN_COUNT = Math.min(10, Math.max(1, Number(process.env.CURSOR_COMPOSER_BENCHMARK_TURNS ?? 10)));
 const TOOL_RESULT_TARGET_BYTES = Math.max(12_000, Number(process.env.CURSOR_COMPOSER_BENCHMARK_TOOL_BYTES ?? 32_000));
+const BENCHMARK_ORDER = ["optimized", "original"] as const;
 
 type Usage = {
 	inputTokens?: number;
@@ -268,7 +269,7 @@ function summarize(records: TurnRecord[]) {
 	};
 }
 
-async function writeOutputs(original: TurnRecord[], optimized: TurnRecord[]) {
+async function writeOutputs(original: TurnRecord[], optimized: TurnRecord[], runOrder: string[]) {
 	await mkdir(OUTPUT_DIR, { recursive: true });
 	const stamp = new Date().toISOString().replace(/[:.]/g, "-");
 	const recordsPath = join(OUTPUT_DIR, `cursor-truncation-benchmark-${stamp}.jsonl`);
@@ -281,6 +282,7 @@ async function writeOutputs(original: TurnRecord[], optimized: TurnRecord[]) {
 		generatedAt: new Date().toISOString(),
 		turns: TURN_COUNT,
 		toolResultTargetBytes: TOOL_RESULT_TARGET_BYTES,
+		runOrder,
 		original: originalSummary,
 		optimized: optimizedSummary,
 		reductions: {
@@ -311,10 +313,14 @@ async function main() {
 	const workspace = await createBenchmarkWorkspace();
 	try {
 		console.log(`benchmarkWorkspace=${workspace}`);
-		console.log(`turns=${TURN_COUNT} toolResultTargetBytes=${TOOL_RESULT_TARGET_BYTES}`);
-		const original = await runVariant("original", workspace, corpus);
-		const optimized = await runVariant("optimized", workspace, corpus);
-		await writeOutputs(original, optimized);
+		console.log(`turns=${TURN_COUNT} toolResultTargetBytes=${TOOL_RESULT_TARGET_BYTES} order=${BENCHMARK_ORDER.join(",")}`);
+		let original: TurnRecord[] = [];
+		let optimized: TurnRecord[] = [];
+		for (const variant of BENCHMARK_ORDER) {
+			if (variant === "optimized") optimized = await runVariant("optimized", workspace, corpus);
+			else original = await runVariant("original", workspace, corpus);
+		}
+		await writeOutputs(original, optimized, [...BENCHMARK_ORDER]);
 	} finally {
 		if (process.env.CURSOR_COMPOSER_KEEP_BENCHMARK_WORKSPACE !== "true") {
 			await rm(workspace, { recursive: true, force: true });

--- a/pi-extension-cursor-composer/scripts/cursor-usage-smoke.ts
+++ b/pi-extension-cursor-composer/scripts/cursor-usage-smoke.ts
@@ -1,0 +1,105 @@
+import { Agent } from "@cursor/sdk";
+import { serializeProviderContext } from "../context.ts";
+
+const MODEL_ID = "composer-2.5";
+
+type Usage = {
+	inputTokens?: number;
+	outputTokens?: number;
+	cacheReadTokens?: number;
+	cacheWriteTokens?: number;
+};
+
+function bytes(text: string): number {
+	return Buffer.byteLength(text, "utf8");
+}
+
+function makeContext(extraUserText = "Reply with exactly: OK") {
+	const hugeToolText = Array.from(
+		{ length: 1_200 },
+		(_, i) => `fixture-line-${i.toString().padStart(4, "0")} ${"x".repeat(90)}`,
+	).join("\n");
+	return {
+		systemPrompt: "You are a smoke-test assistant. Do not edit files. Do not run shell commands unless explicitly required.",
+		messages: [
+			{ role: "user", content: [{ type: "text", text: "Read this large prior tool output and keep it in mind." }] },
+			{ role: "toolResult", toolName: "read", content: [{ type: "text", text: hugeToolText }] },
+			{ role: "assistant", content: [{ type: "text", text: "Acknowledged the prior tool output." }] },
+			{ role: "user", content: [{ type: "text", text: extraUserText }] },
+		],
+	};
+}
+
+function totalUsage(usage: Usage | undefined): number {
+	if (!usage) return 0;
+	return (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0) + (usage.cacheReadTokens ?? 0) + (usage.cacheWriteTokens ?? 0);
+}
+
+function usageSummary(usage: Usage | undefined): string {
+	if (!usage) return "usage=none";
+	return `input=${usage.inputTokens ?? 0} output=${usage.outputTokens ?? 0} cacheRead=${usage.cacheReadTokens ?? 0} cacheWrite=${usage.cacheWriteTokens ?? 0} total=${totalUsage(usage)}`;
+}
+
+async function runPrompt(label: string, prompt: string): Promise<Usage | undefined> {
+	const apiKey = process.env.CURSOR_API_KEY;
+	if (!apiKey) throw new Error("CURSOR_API_KEY is required for live smoke test");
+	let usage: Usage | undefined;
+	const agent = await Agent.create({
+		apiKey,
+		model: { id: MODEL_ID },
+		mode: "plan",
+		local: {
+			cwd: process.cwd(),
+			autoReview: false,
+			sandboxOptions: { enabled: false },
+		},
+	});
+	try {
+		const run = await agent.send(prompt, {
+			mode: "plan",
+			onDelta: ({ update }: { update: any }) => {
+				if (update?.type === "turn-ended" && update.usage) usage = update.usage;
+			},
+		});
+		const result = await run.wait();
+		console.log(`${label}: status=${result?.status ?? "unknown"} promptBytes=${bytes(prompt)} ${usageSummary(usage)}`);
+		console.log(`${label}: result=${String(result?.result ?? "").slice(0, 200).replace(/\s+/g, " ")}`);
+		return usage;
+	} finally {
+		await agent[Symbol.asyncDispose]?.();
+		agent.close?.();
+	}
+}
+
+async function main() {
+	if (!process.argv.includes("--live") && process.env.CURSOR_COMPOSER_LIVE_SMOKE !== "true") {
+		console.log("Dry run only. Set CURSOR_COMPOSER_LIVE_SMOKE=true or pass --live to call Cursor.");
+	}
+	const live = process.argv.includes("--live") || process.env.CURSOR_COMPOSER_LIVE_SMOKE === "true";
+	const context = makeContext();
+	const baseline = serializeProviderContext(context, { truncateToolResults: false });
+	const optimized = serializeProviderContext(context, {
+		truncateToolResults: true,
+		maxToolResultBytes: 8_000,
+		maxToolResultLines: 80,
+	});
+
+	console.log(`baselinePromptBytes=${bytes(baseline)}`);
+	console.log(`optimizedPromptBytes=${bytes(optimized)}`);
+	console.log(`reduction=${((1 - bytes(optimized) / bytes(baseline)) * 100).toFixed(1)}%`);
+	if (bytes(optimized) >= bytes(baseline) * 0.2) {
+		throw new Error("optimized prompt should be at least 80% smaller than baseline for the smoke fixture");
+	}
+	if (!live) return;
+
+	const baselineUsage = await runPrompt("baseline", baseline);
+	const optimizedUsage = await runPrompt("optimized", optimized);
+	if (totalUsage(optimizedUsage) >= totalUsage(baselineUsage)) {
+		throw new Error("optimized live Cursor usage should be lower than baseline live Cursor usage");
+	}
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exitCode = 1;
+});

--- a/pi-extension-cursor-composer/scripts/cursor-usage-smoke.ts
+++ b/pi-extension-cursor-composer/scripts/cursor-usage-smoke.ts
@@ -1,5 +1,10 @@
-import { Agent } from "@cursor/sdk";
-import { serializeProviderContext } from "../context.ts";
+import { Agent, type SDKCustomTool } from "@cursor/sdk";
+import {
+	TOOL_RESULT_RECOVERY_TOOL_NAME,
+	createToolResultRecoveryCustomTools,
+	serializeProviderContext,
+	serializeProviderContextWithMetadata,
+} from "../context.ts";
 
 const MODEL_ID = "composer-2.5";
 
@@ -17,7 +22,7 @@ function bytes(text: string): number {
 function makeContext(extraUserText = "Reply with exactly: OK") {
 	const hugeToolText = Array.from(
 		{ length: 1_200 },
-		(_, i) => `fixture-line-${i.toString().padStart(4, "0")} ${"x".repeat(90)}`,
+		(_, i) => `fixture-line-${i.toString().padStart(4, "0")} ${i === 600 ? "RECOVERY-SENTINEL-0600" : "x".repeat(90)}`,
 	).join("\n");
 	return {
 		systemPrompt: "You are a smoke-test assistant. Do not edit files. Do not run shell commands unless explicitly required.",
@@ -40,7 +45,7 @@ function usageSummary(usage: Usage | undefined): string {
 	return `input=${usage.inputTokens ?? 0} output=${usage.outputTokens ?? 0} cacheRead=${usage.cacheReadTokens ?? 0} cacheWrite=${usage.cacheWriteTokens ?? 0} total=${totalUsage(usage)}`;
 }
 
-async function runPrompt(label: string, prompt: string): Promise<Usage | undefined> {
+async function runPrompt(label: string, prompt: string, customTools?: Record<string, SDKCustomTool>): Promise<{ usage: Usage | undefined; result: string }> {
 	const apiKey = process.env.CURSOR_API_KEY;
 	if (!apiKey) throw new Error("CURSOR_API_KEY is required for live smoke test");
 	let usage: Usage | undefined;
@@ -52,6 +57,7 @@ async function runPrompt(label: string, prompt: string): Promise<Usage | undefin
 			cwd: process.cwd(),
 			autoReview: false,
 			sandboxOptions: { enabled: false },
+			...(customTools ? { customTools } : {}),
 		},
 	});
 	try {
@@ -62,9 +68,10 @@ async function runPrompt(label: string, prompt: string): Promise<Usage | undefin
 			},
 		});
 		const result = await run.wait();
+		const resultText = String(result?.result ?? "");
 		console.log(`${label}: status=${result?.status ?? "unknown"} promptBytes=${bytes(prompt)} ${usageSummary(usage)}`);
-		console.log(`${label}: result=${String(result?.result ?? "").slice(0, 200).replace(/\s+/g, " ")}`);
-		return usage;
+		console.log(`${label}: result=${resultText.slice(0, 200).replace(/\s+/g, " ")}`);
+		return { usage, result: resultText };
 	} finally {
 		await agent[Symbol.asyncDispose]?.();
 		agent.close?.();
@@ -78,10 +85,15 @@ async function main() {
 	const live = process.argv.includes("--live") || process.env.CURSOR_COMPOSER_LIVE_SMOKE === "true";
 	const context = makeContext();
 	const baseline = serializeProviderContext(context, { truncateToolResults: false });
-	const optimized = serializeProviderContext(context, {
+	const optimizedResult = serializeProviderContextWithMetadata(context, {
 		truncateToolResults: true,
 		maxToolResultBytes: 8_000,
 		maxToolResultLines: 80,
+	});
+	const optimized = optimizedResult.prompt;
+	const recoveryTools = createToolResultRecoveryCustomTools(optimizedResult.metadata.toolResultRecoveryRecords, {
+		maxBytes: 8_000,
+		maxLineCount: 200,
 	});
 
 	console.log(`baselinePromptBytes=${bytes(baseline)}`);
@@ -92,10 +104,33 @@ async function main() {
 	}
 	if (!live) return;
 
-	const baselineUsage = await runPrompt("baseline", baseline);
-	const optimizedUsage = await runPrompt("optimized", optimized);
-	if (totalUsage(optimizedUsage) >= totalUsage(baselineUsage)) {
+	const baselineRun = await runPrompt("baseline", baseline);
+	const optimizedRun = await runPrompt("optimized", optimized, recoveryTools);
+	if (totalUsage(optimizedRun.usage) >= totalUsage(baselineRun.usage)) {
 		throw new Error("optimized live Cursor usage should be lower than baseline live Cursor usage");
+	}
+
+	const recoveryPrompt = serializeProviderContextWithMetadata(
+		makeContext(
+			`Use the ${TOOL_RESULT_RECOVERY_TOOL_NAME} tool with the visible Recovery ID to retrieve line 601 of the prior tool result, then reply with exactly the recovered line.`,
+		),
+		{
+			truncateToolResults: true,
+			maxToolResultBytes: 8_000,
+			maxToolResultLines: 80,
+			recoveryIdFactory: () => "smoke-recovery-read-1",
+		},
+	);
+	const recoveryRun = await runPrompt(
+		"recovery",
+		recoveryPrompt.prompt,
+		createToolResultRecoveryCustomTools(recoveryPrompt.metadata.toolResultRecoveryRecords, {
+			maxBytes: 8_000,
+			maxLineCount: 200,
+		}),
+	);
+	if (!recoveryRun.result.includes("fixture-line-0600 RECOVERY-SENTINEL-0600")) {
+		throw new Error(`${TOOL_RESULT_RECOVERY_TOOL_NAME} live recovery smoke did not return the hidden sentinel line`);
 	}
 }
 

--- a/pi-extension-cursor-composer/tests/context-serialization.test.ts
+++ b/pi-extension-cursor-composer/tests/context-serialization.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	previewTextByBytesAndLines,
+	serializeProviderContext,
+	serializeToolResultContent,
+} from "../context.ts";
+
+function contextWithToolResult(toolText: string) {
+	return {
+		systemPrompt: "system instructions stay visible",
+		messages: [
+			{ role: "user", content: [{ type: "text", text: "please inspect the file" }] },
+			{ role: "toolResult", toolName: "read", content: [{ type: "text", text: toolText }] },
+			{ role: "assistant", content: [{ type: "text", text: "I inspected it." }] },
+			{ role: "user", content: [{ type: "text", text: "now summarize" }] },
+		],
+	};
+}
+
+test("small tool results remain intact", () => {
+	const small = "alpha\nbeta\ngamma";
+	const prompt = serializeProviderContext(contextWithToolResult(small), {
+		truncateToolResults: true,
+		maxToolResultBytes: 1_000,
+		maxToolResultLines: 100,
+	});
+	assert.match(prompt, /# Pi system prompt/);
+	assert.match(prompt, /## user/);
+	assert.match(prompt, /## toolResult read/);
+	assert.match(prompt, /alpha\nbeta\ngamma/);
+	assert.doesNotMatch(prompt, /Large tool result truncated/);
+});
+
+test("large tool results are previewed with metadata while preserving conversation skeleton", () => {
+	const huge = Array.from({ length: 2_000 }, (_, i) => `line-${i.toString().padStart(4, "0")} ${"x".repeat(80)}`).join("\n");
+	const unoptimized = serializeProviderContext(contextWithToolResult(huge), {
+		truncateToolResults: false,
+	});
+	const optimized = serializeProviderContext(contextWithToolResult(huge), {
+		truncateToolResults: true,
+		maxToolResultBytes: 4_000,
+		maxToolResultLines: 50,
+	});
+
+	assert.ok(optimized.length < unoptimized.length * 0.2, `expected optimized prompt to be <20% of baseline (${optimized.length}/${unoptimized.length})`);
+	assert.match(optimized, /# Pi system prompt/);
+	assert.match(optimized, /## user/);
+	assert.match(optimized, /## toolResult read/);
+	assert.match(optimized, /## assistant/);
+	assert.match(optimized, /Original: 2000 lines/);
+	assert.match(optimized, /If exact content is needed, use available tools to re-read/);
+	assert.match(optimized, /<tool_result_preview>/);
+	assert.match(optimized, /line-0000/);
+	assert.doesNotMatch(optimized, /line-1999/);
+});
+
+test("tool-result truncation can be disabled", () => {
+	const huge = "a".repeat(20_000);
+	const rendered = serializeToolResultContent([{ type: "text", text: huge }], {
+		truncateToolResults: false,
+		maxToolResultBytes: 10,
+		maxToolResultLines: 1,
+	});
+	assert.equal(rendered, huge);
+});
+
+test("preview respects byte and line ceilings", () => {
+	const preview = previewTextByBytesAndLines("one\ntwo\nthree\nfour", 9, 2);
+	assert.equal(preview.truncated, true);
+	assert.equal(preview.text, "one\ntwo");
+	assert.equal(preview.previewLines, 2);
+	assert.ok(preview.previewBytes <= 9);
+});

--- a/pi-extension-cursor-composer/tests/context-serialization.test.ts
+++ b/pi-extension-cursor-composer/tests/context-serialization.test.ts
@@ -3,6 +3,9 @@ import test from "node:test";
 import {
 	DEFAULT_PROVIDER_TOOL_RESULT_MAX_BYTES,
 	DEFAULT_PROVIDER_TOOL_RESULT_MAX_LINES,
+	TOOL_RESULT_RECOVERY_TOOL_NAME,
+	createToolResultRecoveryCustomTools,
+	deterministicToolResultRecoveryId,
 	previewTextByBytesAndLines,
 	providerToolResultSerializationOptionsFromEnv,
 	serializeProviderContext,
@@ -10,12 +13,12 @@ import {
 	serializeToolResultContent,
 } from "../context.ts";
 
-function contextWithToolResult(toolText: string, toolName = "read") {
+function contextWithToolResult(toolText: string, toolName = "read", toolCallId = "call-read-1") {
 	return {
 		systemPrompt: "system instructions stay visible",
 		messages: [
 			{ role: "user", content: [{ type: "text", text: "please inspect the file" }] },
-			{ role: "toolResult", toolName, content: [{ type: "text", text: toolText }] },
+			{ role: "toolResult", toolName, toolCallId, content: [{ type: "text", text: toolText }] },
 			{ role: "assistant", content: [{ type: "text", text: "I inspected it." }] },
 			{ role: "user", content: [{ type: "text", text: "now summarize" }] },
 		],
@@ -45,6 +48,7 @@ test("large tool results are previewed with metadata while preserving conversati
 		truncateToolResults: true,
 		maxToolResultBytes: 4_000,
 		maxToolResultLines: 50,
+		recoveryIdFactory: () => "test-recovery-read-1",
 	});
 
 	assert.ok(optimized.length < unoptimized.length * 0.25, `expected optimized prompt to be <25% of baseline (${optimized.length}/${unoptimized.length})`);
@@ -53,16 +57,21 @@ test("large tool results are previewed with metadata while preserving conversati
 	assert.match(optimized, /## toolResult read/);
 	assert.match(optimized, /## assistant/);
 	assert.match(optimized, /Original: 2000 lines/);
+	assert.match(optimized, /Recovery ID: test-recovery-read-1/);
 	assert.match(optimized, /Original SHA-256: [a-f0-9]{64}/);
-	assert.match(optimized, /If exact historical content is required/);
+	assert.match(optimized, new RegExp(`call the Cursor local tool ${TOOL_RESULT_RECOVERY_TOOL_NAME}`));
 	assert.match(optimized, /<tool_result_preview_head>/);
 	assert.match(optimized, /<tool_result_preview_tail>/);
 	assert.match(optimized, /line-0000/);
 	assert.match(optimized, /line-1999/);
 	assert.equal(metadata.truncatedToolResults.length, 1);
 	assert.equal(metadata.truncatedToolResults[0].toolName, "read");
+	assert.equal(metadata.truncatedToolResults[0].recoveryId, "test-recovery-read-1");
 	assert.equal(metadata.truncatedToolResults[0].originalLines, 2_000);
 	assert.ok(metadata.truncatedToolResults[0].omittedBytes > 0);
+	assert.equal(metadata.toolResultRecoveryRecords.length, 1);
+	assert.equal(metadata.toolResultRecoveryRecords[0].id, "test-recovery-read-1");
+	assert.equal(metadata.toolResultRecoveryRecords[0].text, huge);
 });
 
 test("tool-result truncation can be disabled", () => {
@@ -73,6 +82,89 @@ test("tool-result truncation can be disabled", () => {
 		maxToolResultLines: 1,
 	});
 	assert.equal(rendered, huge);
+});
+
+test("recovery custom tool returns exact omitted tool-result slices", async () => {
+	const huge = Array.from({ length: 300 }, (_, i) => `line-${i.toString().padStart(3, "0")}${i === 150 ? " MIDDLE-SENTINEL" : ""}`).join("\n");
+	const { prompt, metadata } = serializeProviderContextWithMetadata(contextWithToolResult(huge, "bash"), {
+		truncateToolResults: true,
+		maxToolResultBytes: 900,
+		maxToolResultLines: 20,
+		recoveryIdFactory: () => "test-recovery-bash-1",
+	});
+	assert.match(prompt, /Recovery ID: test-recovery-bash-1/);
+	assert.doesNotMatch(prompt, /MIDDLE-SENTINEL/);
+
+	const tools = createToolResultRecoveryCustomTools(metadata.toolResultRecoveryRecords, {
+		defaultLineCount: 5,
+		maxLineCount: 20,
+		maxBytes: 2_000,
+	});
+	assert.ok(tools);
+	const recoveryTool = tools[TOOL_RESULT_RECOVERY_TOOL_NAME] as {
+		execute: (args: Record<string, unknown>) => Promise<any> | any;
+	};
+	const result = await recoveryTool.execute({ id: "test-recovery-bash-1", startLine: 151, lineCount: 1 });
+	assert.equal(result.isError, undefined);
+	assert.equal(result.structuredContent.id, "test-recovery-bash-1");
+	assert.equal(result.structuredContent.startLine, 151);
+	assert.equal(result.structuredContent.endLine, 151);
+	assert.match(result.content[0].text, /line-150 MIDDLE-SENTINEL/);
+	assert.match(result.content[0].text, /Original: 300 lines/);
+	assert.match(result.content[0].text, /SHA-256 [a-f0-9]{64}/);
+
+	const pastEnd = await recoveryTool.execute({ id: "test-recovery-bash-1", startLine: 9999 });
+	assert.equal(pastEnd.isError, true);
+	assert.match(pastEnd.content[0].text, /past the end/);
+	assert.equal(pastEnd.structuredContent.returnedBytes, 0);
+
+	const missing = await recoveryTool.execute({ id: "does-not-exist" });
+	assert.equal(missing.isError, true);
+	assert.equal(missing.structuredContent.found, false);
+});
+
+test("recovery custom tool preserves original CRLF line endings in returned slices", async () => {
+	const crlfText = Array.from({ length: 120 }, (_, i) => `crlf-line-${i.toString().padStart(3, "0")}`).join("\r\n");
+	const { metadata } = serializeProviderContextWithMetadata(contextWithToolResult(crlfText, "read", "call-crlf-1"), {
+		truncateToolResults: true,
+		maxToolResultBytes: 500,
+		maxToolResultLines: 10,
+		recoveryIdFactory: () => "test-recovery-crlf-1",
+	});
+	const tools = createToolResultRecoveryCustomTools(metadata.toolResultRecoveryRecords, {
+		defaultLineCount: 5,
+		maxLineCount: 20,
+		maxBytes: 2_000,
+	});
+	assert.ok(tools);
+	const recoveryTool = tools[TOOL_RESULT_RECOVERY_TOOL_NAME] as {
+		execute: (args: Record<string, unknown>) => Promise<any> | any;
+	};
+	const result = await recoveryTool.execute({ id: "test-recovery-crlf-1", startLine: 51, lineCount: 3 });
+	const expectedSlice = "crlf-line-050\r\ncrlf-line-051\r\ncrlf-line-052\r\n";
+	assert.match(result.content[0].text, /<recovered_tool_result>/);
+	assert.ok(result.content[0].text.includes(expectedSlice), result.content[0].text);
+});
+
+test("deterministic recovery IDs are stable across serializations and tied to tool-result identity", () => {
+	const huge = Array.from({ length: 200 }, (_, i) => `stable-line-${i} ${"x".repeat(80)}`).join("\n");
+	const options = { truncateToolResults: true, maxToolResultBytes: 1_000, maxToolResultLines: 10 };
+	const first = serializeProviderContextWithMetadata(contextWithToolResult(huge, "read", "call-stable-1"), options);
+	const second = serializeProviderContextWithMetadata(contextWithToolResult(huge, "read", "call-stable-1"), options);
+	const changedContent = serializeProviderContextWithMetadata(contextWithToolResult(`${huge}\nchanged`, "read", "call-stable-1"), options);
+	const changedCall = serializeProviderContextWithMetadata(contextWithToolResult(huge, "read", "call-stable-2"), options);
+
+	const firstId = first.metadata.truncatedToolResults[0].recoveryId;
+	assert.match(firstId ?? "", /^ptr_[a-f0-9]{24}$/);
+	assert.equal(second.metadata.truncatedToolResults[0].recoveryId, firstId);
+	assert.equal(first.metadata.toolResultRecoveryRecords[0].id, firstId);
+	assert.match(first.prompt, new RegExp(`Recovery ID: ${firstId}`));
+	assert.equal(
+		deterministicToolResultRecoveryId("read", "call-stable-1", first.metadata.truncatedToolResults[0].sha256),
+		firstId,
+	);
+	assert.notEqual(changedContent.metadata.truncatedToolResults[0].recoveryId, firstId);
+	assert.notEqual(changedCall.metadata.truncatedToolResults[0].recoveryId, firstId);
 });
 
 test("preview preserves head and tail while respecting byte and line content ceilings", () => {

--- a/pi-extension-cursor-composer/tests/context-serialization.test.ts
+++ b/pi-extension-cursor-composer/tests/context-serialization.test.ts
@@ -1,17 +1,21 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+	DEFAULT_PROVIDER_TOOL_RESULT_MAX_BYTES,
+	DEFAULT_PROVIDER_TOOL_RESULT_MAX_LINES,
 	previewTextByBytesAndLines,
+	providerToolResultSerializationOptionsFromEnv,
 	serializeProviderContext,
+	serializeProviderContextWithMetadata,
 	serializeToolResultContent,
 } from "../context.ts";
 
-function contextWithToolResult(toolText: string) {
+function contextWithToolResult(toolText: string, toolName = "read") {
 	return {
 		systemPrompt: "system instructions stay visible",
 		messages: [
 			{ role: "user", content: [{ type: "text", text: "please inspect the file" }] },
-			{ role: "toolResult", toolName: "read", content: [{ type: "text", text: toolText }] },
+			{ role: "toolResult", toolName, content: [{ type: "text", text: toolText }] },
 			{ role: "assistant", content: [{ type: "text", text: "I inspected it." }] },
 			{ role: "user", content: [{ type: "text", text: "now summarize" }] },
 		],
@@ -37,22 +41,28 @@ test("large tool results are previewed with metadata while preserving conversati
 	const unoptimized = serializeProviderContext(contextWithToolResult(huge), {
 		truncateToolResults: false,
 	});
-	const optimized = serializeProviderContext(contextWithToolResult(huge), {
+	const { prompt: optimized, metadata } = serializeProviderContextWithMetadata(contextWithToolResult(huge), {
 		truncateToolResults: true,
 		maxToolResultBytes: 4_000,
 		maxToolResultLines: 50,
 	});
 
-	assert.ok(optimized.length < unoptimized.length * 0.2, `expected optimized prompt to be <20% of baseline (${optimized.length}/${unoptimized.length})`);
+	assert.ok(optimized.length < unoptimized.length * 0.25, `expected optimized prompt to be <25% of baseline (${optimized.length}/${unoptimized.length})`);
 	assert.match(optimized, /# Pi system prompt/);
 	assert.match(optimized, /## user/);
 	assert.match(optimized, /## toolResult read/);
 	assert.match(optimized, /## assistant/);
 	assert.match(optimized, /Original: 2000 lines/);
-	assert.match(optimized, /If exact content is needed, use available tools to re-read/);
-	assert.match(optimized, /<tool_result_preview>/);
+	assert.match(optimized, /Original SHA-256: [a-f0-9]{64}/);
+	assert.match(optimized, /If exact historical content is required/);
+	assert.match(optimized, /<tool_result_preview_head>/);
+	assert.match(optimized, /<tool_result_preview_tail>/);
 	assert.match(optimized, /line-0000/);
-	assert.doesNotMatch(optimized, /line-1999/);
+	assert.match(optimized, /line-1999/);
+	assert.equal(metadata.truncatedToolResults.length, 1);
+	assert.equal(metadata.truncatedToolResults[0].toolName, "read");
+	assert.equal(metadata.truncatedToolResults[0].originalLines, 2_000);
+	assert.ok(metadata.truncatedToolResults[0].omittedBytes > 0);
 });
 
 test("tool-result truncation can be disabled", () => {
@@ -65,10 +75,81 @@ test("tool-result truncation can be disabled", () => {
 	assert.equal(rendered, huge);
 });
 
-test("preview respects byte and line ceilings", () => {
+test("preview preserves head and tail while respecting byte and line content ceilings", () => {
 	const preview = previewTextByBytesAndLines("one\ntwo\nthree\nfour", 9, 2);
 	assert.equal(preview.truncated, true);
-	assert.equal(preview.text, "one\ntwo");
-	assert.equal(preview.previewLines, 2);
+	assert.match(preview.headText, /one/);
+	assert.match(preview.tailText, /four/);
+	assert.ok(preview.previewLines <= 2);
 	assert.ok(preview.previewBytes <= 9);
+});
+
+test("env parser uses Pi-sized defaults and accepts common false values", () => {
+	assert.deepEqual(providerToolResultSerializationOptionsFromEnv({}), {
+		truncateToolResults: true,
+		maxToolResultBytes: DEFAULT_PROVIDER_TOOL_RESULT_MAX_BYTES,
+		maxToolResultLines: DEFAULT_PROVIDER_TOOL_RESULT_MAX_LINES,
+	});
+	for (const value of ["0", "false", "no", "off"]) {
+		assert.equal(providerToolResultSerializationOptionsFromEnv({ CURSOR_COMPOSER_PROVIDER_TRUNCATE_TOOL_RESULTS: value }).truncateToolResults, false);
+	}
+	assert.deepEqual(
+		providerToolResultSerializationOptionsFromEnv({}, { maxToolResultBytes: 12_345, maxToolResultLines: 678 }),
+		{ truncateToolResults: true, maxToolResultBytes: 12_345, maxToolResultLines: 678 },
+	);
+	assert.equal(DEFAULT_PROVIDER_TOOL_RESULT_MAX_BYTES, 51_200);
+	assert.equal(DEFAULT_PROVIDER_TOOL_RESULT_MAX_LINES, 2_000);
+});
+
+test("ten-turn provider context keeps conversation structure while truncating large historical tool outputs", () => {
+	const messages: Array<{ role: string; content: Array<{ type: string; text: string }>; toolName?: string }> = [];
+	for (let turn = 1; turn <= 10; turn += 1) {
+		messages.push({
+			role: "user",
+			content: [{ type: "text", text: `turn-${turn}: inspect evidence and answer with the turn marker` }],
+		});
+		const toolName = turn % 2 === 0 ? "bash" : "read";
+		const tailMarker = toolName === "bash" ? `TURN-${turn}-TAIL-EXIT-STATUS-1` : `TURN-${turn}-TAIL-FILE-END`;
+		const toolText = Array.from(
+			{ length: 120 },
+			(_, line) => `turn-${turn} ${toolName} line-${line.toString().padStart(3, "0")} ${line === 119 ? tailMarker : "x".repeat(60)}`,
+		).join("\n");
+		messages.push({
+			role: "toolResult",
+			toolName,
+			content: [{ type: "text", text: toolText }],
+		});
+		messages.push({
+			role: "assistant",
+			content: [{ type: "text", text: `turn-${turn}: evidence acknowledged` }],
+		});
+	}
+	messages.push({
+		role: "user",
+		content: [{ type: "text", text: "final: summarize all ten turns" }],
+	});
+
+	const context = { systemPrompt: "system instructions stay visible", messages };
+	const baseline = serializeProviderContext(context, { truncateToolResults: false });
+	const { prompt, metadata } = serializeProviderContextWithMetadata(context, {
+		truncateToolResults: true,
+		maxToolResultBytes: 1_000,
+		maxToolResultLines: 12,
+	});
+
+	assert.ok(prompt.length < baseline.length * 0.3, `expected ten-turn optimized prompt to be <30% of baseline (${prompt.length}/${baseline.length})`);
+	assert.equal(metadata.truncatedToolResults.length, 10);
+	assert.equal(metadata.truncatedToolResults.filter((item) => item.toolName === "bash").length, 5);
+	assert.equal(metadata.truncatedToolResults.filter((item) => item.toolName === "read").length, 5);
+	assert.match(prompt, /# Pi system prompt/);
+	assert.match(prompt, /final: summarize all ten turns/);
+	for (let turn = 1; turn <= 10; turn += 1) {
+		assert.match(prompt, new RegExp(`turn-${turn}: inspect evidence`));
+		assert.match(prompt, new RegExp(`turn-${turn}: evidence acknowledged`));
+		assert.match(prompt, new RegExp(`turn-${turn} (bash|read) line-000`));
+		assert.match(prompt, new RegExp(`TURN-${turn}-TAIL-(EXIT-STATUS-1|FILE-END)`));
+	}
+	assert.match(prompt, /Original SHA-256: [a-f0-9]{64}/);
+	assert.match(prompt, /<tool_result_preview_head>/);
+	assert.match(prompt, /<tool_result_preview_tail>/);
 });


### PR DESCRIPTION
## Summary

This PR reduces token usage for the `cursor-composer/composer-2.5` native Pi provider when prior Pi tool outputs are large.

Previously, the provider serialized the full Pi conversation into every Cursor SDK Composer call, including complete historical `toolResult` payloads from tools such as `read` and `bash`. In long Pi sessions, this can cause very large repeated prompts because old tool outputs are resent to Cursor on every provider turn.

This change keeps the full conversation structure, but safely truncates large historical `toolResult` bodies by default before replaying provider context into Cursor Composer.

## Problem

The native provider currently builds one prompt from the whole Pi context for every Cursor Composer call. That means a large previous tool result, for example a large file read or command output, is included again and again in later provider requests.

Observed impact:

- Prompt size grows quickly across turns.
- Cursor-reported usage can spike heavily.
- The repeated content is often stale historical evidence rather than the latest user request.
- The provider had no default protection against resending very large old tool outputs.

## Approach

This PR extracts provider context serialization into `context.ts` and adds safe truncation for large `toolResult` messages.

For large tool results, the provider now preserves:

- the original role/message structure;
- the `toolResult` header and tool name;
- original line and byte counts;
- included preview line and byte counts;
- a leading preview of the result;
- an explicit instruction that Cursor should re-read/rerun the relevant tool if exact omitted content is needed.

Small tool results remain unchanged.

The optimization is enabled by default but can be disabled to restore previous behavior:

```bash
CURSOR_COMPOSER_PROVIDER_TRUNCATE_TOOL_RESULTS=false
```

The truncation limits are configurable:

```bash
CURSOR_COMPOSER_PROVIDER_TOOL_RESULT_MAX_BYTES=32000
CURSOR_COMPOSER_PROVIDER_TOOL_RESULT_MAX_LINES=500
```

`/cursor-composer-status` now reports whether provider tool-result truncation is on or off.

## What this intentionally does not change

This PR does **not** change:

- the `/cursor-composer` command behavior;
- the `cursor_composer_agent` tool behavior;
- provider registration;
- Cursor SDK model selection;
- pricing/usage mapping;
- auto-review or sandbox behavior;
- heartbeat/progress behavior;
- non-tool conversation messages;
- small tool results under the configured limits.

This PR also does **not** add provider session reuse. We tested that idea separately, but Cursor SDK still reported prior conversation/cache usage on follow-up calls, so it was removed to keep this improvement simple and focused on the proven token reduction.

## Validation

### Package tests

```bash
cd pi-extension-cursor-composer
npm test
```

Result:

```text
# tests 4
# pass 4
# fail 0
```

Covered behavior:

- small tool results remain intact;
- large tool results are replaced with preview + metadata;
- conversation skeleton is preserved;
- truncation can be disabled;
- byte and line preview limits are respected.

### Dry smoke test

```bash
cd pi-extension-cursor-composer
npm run smoke:cursor
```

Result:

```text
baselinePromptBytes=131298
optimizedPromptBytes=8916
reduction=93.2%
```

### Live Cursor smoke test

```bash
cd pi-extension-cursor-composer
CURSOR_COMPOSER_LIVE_SMOKE=true npm run smoke:cursor
```

Result:

```text
baseline:  total=40943
optimized: total=17093
```

This is about a **58.2% reduction** in Cursor-reported total tokens for the smoke fixture.

### Live 10-turn benchmark

```bash
cd pi-extension-cursor-composer
CURSOR_COMPOSER_LIVE_BENCHMARK=true npm run benchmark:cursor
```

The benchmark runs the same 10-turn fixture twice:

1. original full tool-result replay;
2. optimized tool-result truncation.

It uses Cursor SDK Composer in agent mode against a temporary local workspace and asks it to inspect package files across multiple turns.

Summary:

```json
{
  "original": {
    "totalPromptBytes": 1807828,
    "totalTokens": 3561965,
    "inputTokens": 2141983,
    "cacheReadTokens": 1413020,
    "jsonLike": 10,
    "nonEmpty": 10,
    "mentionsExpectedEvidence": 10,
    "refusalOrUnable": 0,
    "toolLikeEvents": 194
  },
  "optimized": {
    "totalPromptBytes": 218896,
    "totalTokens": 1152913,
    "inputTokens": 681634,
    "cacheReadTokens": 463267,
    "jsonLike": 10,
    "nonEmpty": 10,
    "mentionsExpectedEvidence": 10,
    "refusalOrUnable": 0,
    "toolLikeEvents": 219
  },
  "reductions": {
    "promptBytesPct": 87.9,
    "totalTokensPct": 67.6,
    "inputTokensPct": 68.2
  }
}
```

Observed benchmark impact:

- prompt bytes reduced by **87.9%**;
- Cursor-reported total tokens reduced by **67.6%**;
- Cursor-reported input tokens reduced by **68.2%**;
- response quality checks remained equivalent:
  - 10/10 non-empty responses for both variants;
  - 10/10 JSON-like responses for both variants;
  - 10/10 responses mentioning expected evidence files for both variants;
  - 0 refusals or “unable to access” responses for both variants.

Benchmark artifacts are local-only and are not included in this PR.

### Publish readiness

Per `CONTRIBUTING.md`, from repo root:

```bash
./dev/scripts/check-publish-readiness.sh --all --check-alt-client
```

Result:

```text
Summary: PASS all checked packages are publish-ready.
```

Warnings were limited to expected environment/version warnings such as unavailable alternate client and already-published package versions.

### Package check

```bash
cd pi-extension-cursor-composer
npm pack --dry-run
```

Confirmed runtime package includes:

```text
LICENSE
README.md
context.ts
index.ts
package.json
```

This matters because `index.ts` now imports the serializer from `context.ts`.

## Notes on benchmark methodology

The benchmark compares the old full tool-result replay behavior with the optimized truncation behavior by toggling serializer options:

- old behavior: `truncateToolResults: false`;
- optimized behavior: `truncateToolResults: true`.

This isolates the behavior being changed by this PR without repeatedly uninstalling/reinstalling package versions.

The live benchmark is opt-in because it calls Cursor and can consume usage. By default, `npm run benchmark:cursor` performs a dry run. Live mode requires explicitly setting:

```bash
CURSOR_COMPOSER_LIVE_BENCHMARK=true
```

The benchmark output files are intentionally local evidence and are ignored via `.gitignore`.
