### PR TITLE
fix(pi-extension-git-footer-status): survive stale extension ctx in background timers

### DIFF
--- a/pi-extension-git-footer-status/index.ts
+++ b/pi-extension-git-footer-status/index.ts
@@ -911,6 +911,24 @@ export default function gitFooterStatus(pi: ExtensionAPI) {
 
   const getFooterContext = (fallback: ExtensionContext): ExtensionContext => latestFooterContext ?? fallback;
 
+  // A captured pi/command ctx becomes stale after ctx.newSession(), ctx.fork(),
+  // ctx.switchSession(), or ctx.reload() — which fresh-context subagents (e.g.
+  // scout) trigger. Accessing a stale ctx (pi.exec, ctx.ui, ctx.cwd, ...)
+  // throws synchronously, which bypasses runGit's `.catch(() => undefined)`
+  // (the throw happens before a promise exists) and surfaces as an unhandled
+  // rejection from the background timers below, killing the subagent process.
+  // Detect it so timer/async refresh paths can stop the dead auto-refresh and
+  // swallow instead of crashing.
+  const isStaleExtensionContextError = (error: unknown): boolean => {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes("extension ctx is stale");
+  };
+
+  const swallowStaleExtensionContext = (error: unknown): void => {
+    if (isStaleExtensionContextError(error)) stopGitAutoRefresh();
+    // Best-effort background work: never propagate.
+  };
+
   const mergeRefreshOptions = (current: GitRefreshOptions | null, next: GitRefreshOptions = {}): GitRefreshOptions => {
     const merged: GitRefreshOptions = {};
     if ((current === null || current.publishIfUnchanged === false) && next.publishIfUnchanged === false) merged.publishIfUnchanged = false;
@@ -939,7 +957,7 @@ export default function gitFooterStatus(pi: ExtensionAPI) {
     rememberFooterContext(ctx);
     promptEstimateRefreshTimer = setTimeout(() => {
       promptEstimateRefreshTimer = null;
-      void refreshPromptInjectionEstimate(getEstimateContext(ctx));
+      void refreshPromptInjectionEstimate(getEstimateContext(ctx)).catch(swallowStaleExtensionContext);
     }, Math.max(0, delayMs));
     promptEstimateRefreshTimer.unref?.();
   };
@@ -1000,10 +1018,14 @@ export default function gitFooterStatus(pi: ExtensionAPI) {
   };
 
   const publishWebuiFooter = (ctx: ExtensionContext, snapshot: GitSnapshot | null = latestGitSnapshot) => {
-    const footerCtx = getFooterContext(ctx);
-    lastWebuiFooterPublishMs = Date.now();
-    const payload = buildWebuiFooterPayload(footerCtx, snapshot, buildFooterTelemetry(footerCtx), latestGitFetchState);
-    footerCtx.ui.setStatus(WEBUI_FOOTER_STATUS_KEY, JSON.stringify(payload));
+    try {
+      const footerCtx = getFooterContext(ctx);
+      lastWebuiFooterPublishMs = Date.now();
+      const payload = buildWebuiFooterPayload(footerCtx, snapshot, buildFooterTelemetry(footerCtx), latestGitFetchState);
+      footerCtx.ui.setStatus(WEBUI_FOOTER_STATUS_KEY, JSON.stringify(payload));
+    } catch (error) {
+      swallowStaleExtensionContext(error);
+    }
   };
 
   const scheduleWebuiFooterPublish = (ctx: ExtensionContext, delayMs = 250) => {
@@ -1113,11 +1135,15 @@ export default function gitFooterStatus(pi: ExtensionAPI) {
     rememberFooterContext(ctx);
     footerUsageRecomputeTimer = setTimeout(() => {
       footerUsageRecomputeTimer = null;
-      const footerCtx = getFooterContext(ctx);
-      footerUsageSnapshot = recomputeFooterUsageSnapshot(footerCtx);
-      refreshPromptCalibrationCapability(footerCtx);
-      requestFooterRender?.();
-      publishWebuiFooter(footerCtx);
+      try {
+        const footerCtx = getFooterContext(ctx);
+        footerUsageSnapshot = recomputeFooterUsageSnapshot(footerCtx);
+        refreshPromptCalibrationCapability(footerCtx);
+        requestFooterRender?.();
+        publishWebuiFooter(footerCtx);
+      } catch (error) {
+        swallowStaleExtensionContext(error);
+      }
     }, Math.max(0, delayMs));
     footerUsageRecomputeTimer.unref?.();
   };
@@ -1194,6 +1220,12 @@ export default function gitFooterStatus(pi: ExtensionAPI) {
           pendingRefreshOptions = null;
           await refreshOnce(getFooterContext(ctx), nextOptions);
         }
+      } catch (error) {
+        // readGitSnapshot -> pi.exec throws "extension ctx is stale"
+        // synchronously when the session that scheduled this auto-refresh was
+        // replaced/reloaded. Stop the timer so we stop poking the dead ctx;
+        // the next session_start restarts it with a fresh ctx.
+        swallowStaleExtensionContext(error);
       } finally {
         refreshPromise = null;
       }
@@ -1405,7 +1437,7 @@ export default function gitFooterStatus(pi: ExtensionAPI) {
     });
 
     void refresh(ctx).then(() => {
-      void runInitialGitFetch(ctx, sessionSerial);
+      void runInitialGitFetch(ctx, sessionSerial).catch(swallowStaleExtensionContext);
     });
     startGitAutoRefresh(ctx);
   });


### PR DESCRIPTION
## Summary

Fixes #8.

`@firstpick/pi-extension-git-footer-status` crashes fresh-context Pi subagents (e.g. `scout`) with an unhandled `This extension ctx is stale ...` rejection thrown from the git footer's background timers, killing the subagent process (exit 1) before it can write its output.

## Root cause

When a fresh-context subagent starts, pi replaces/reloads the session (`ctx.newSession()` / `fork()` / `switchSession()` / `reload()`). The extension runtime marks the previously-captured ctx as stale: `ExtensionRuntime.invalidate()` sets `staleMessage` and every subsequent `pi.*` / `ctx.*` call goes through `assertActive()`, which throws **synchronously**:

```js
// @earendil-works/pi-coding-agent dist/core/extensions/runner.js
exec(command, args, options) {
  runtime.assertActive();          // throws BEFORE a promise is returned
  return execCommand(...);
}
```

The git footer keeps several background timers that capture `pi` / `ctx` (git auto-refresh `setInterval`, throttled `publishWebuiFooter`, `scheduleFooterUsageRecompute`, `schedulePromptInjectionEstimateRefresh`, `runInitialGitFetch`). `runGit` guards its exec with `.catch(() => undefined)`, but because `pi.exec()` throws synchronously **before** a promise is created, the `.catch()` is never attached and the throw propagates. In the auto-refresh path the call is `void refresh(...)`, so the rejected promise has no handler → unhandled rejection → process crash.

Observed scout crash stack:

```
at readGitSnapshot (…/index.ts)
at refreshOnce (…/index.ts)
at refresh (…/index.ts)
at Timeout._onTimeout (…/index.ts)   // startGitAutoRefresh setInterval
```

## Changes

Added two small helpers and guarded every timer/async refresh path:

- `isStaleExtensionContextError(error)` — detects the stale-ctx error by message (`"extension ctx is stale"`).
- `swallowStaleExtensionContext(error)` — on a stale-ctx error, stops the dead auto-refresh timer (`stopGitAutoRefresh()`); always swallows (background refresh is best-effort).
- `refresh` IIFE — `try/catch` (the primary crash path).
- `publishWebuiFooter` — `try/catch` around the body.
- `scheduleFooterUsageRecompute` timer callback — `try/catch`.
- `schedulePromptInjectionEstimateRefresh` timer — `.catch(swallowStaleExtensionContext)` on the `void` async call.
- `runInitialGitFetch` call in `session_start` — `.catch(swallowStaleExtensionContext)`.

`session_start` already calls `startGitAutoRefresh(ctx)` with the fresh ctx, so normal operation resumes for the new session; only the stale timer from the replaced session is silenced. No behavior change for the non-stale path.

## Verification

`node --experimental-strip-types --check index.ts` passes.

Behavioral test loading the real module via `jiti` (the same loader pi uses), with a `pi.exec` that throws the stale-ctx error synchronously (mirroring `assertActive()`):

1. `activate(fakePi)`; emit `session_start` (arms the 50ms auto-refresh `setInterval`).
2. Wait one tick so the initial non-stale `refresh` settles.
3. Flip a `stale` flag so `pi.exec()` throws `Error("This extension ctx is stale ...")` synchronously.
4. Wait for the auto-refresh timer to fire against the stale ctx.

- **Before this fix** (catch removed from `refresh`): `unhandledRejection` with the exact crash stack above, process exits 1.
- **With this fix**: no unhandled rejection, process exits 0; the auto-refresh timer is stopped on the first stale-ctx hit.

No version bump — leaving that to the maintainer's release flow (per `CONTRIBUTING.md`).

/ai generated by glm-5.2
