### PR TITLE
Restore subagent-gate launches after RPC workflow cutover

### DIFF
--- a/pi-package-webui/lib/subagent-gate.mjs
+++ b/pi-package-webui/lib/subagent-gate.mjs
@@ -298,8 +298,8 @@ function modelForAttempt(task, attemptIndex, successfulProviders, requireDistinc
   return { model: available[Math.min(attemptIndex, available.length - 1)], exhausted: false };
 }
 
-function spawnParams(task, model, attemptTimeoutMs) {
-  return {
+function workflowScript(task, model) {
+  const childParams = {
     agent: task.agent,
     task: task.task,
     ...(model ? { model } : {}),
@@ -309,6 +309,16 @@ function spawnParams(task, model, attemptTimeoutMs) {
     ...(task.output !== undefined ? { output: task.output } : {}),
     ...(task.outputMode ? { outputMode: task.outputMode } : {}),
     ...(task.acceptance !== undefined ? { acceptance: task.acceptance } : {}),
+    // The outer workflow is asynchronous; the child must be foreground so its
+    // completed result remains the workflow result consumed by this gate.
+    async: false,
+  };
+  return `return runs.run("gate", ${JSON.stringify(childParams)});`;
+}
+
+function spawnParams(task, model, attemptTimeoutMs) {
+  return {
+    workflowScript: workflowScript(task, model),
     ...(attemptTimeoutMs ? { timeoutMs: attemptTimeoutMs } : {}),
     async: true,
   };

--- a/pi-package-webui/tests/subagent-gate.test.mjs
+++ b/pi-package-webui/tests/subagent-gate.test.mjs
@@ -82,6 +82,15 @@ async function executeFailure(tool, params, signal = new AbortController().signa
   }
 }
 
+function workflowChildParams(request) {
+  const script = request.params?.workflowScript;
+  const prefix = 'return runs.run("gate", ';
+  assert.equal(typeof script, "string");
+  assert.ok(script.startsWith(prefix));
+  assert.ok(script.endsWith(");"));
+  return JSON.parse(script.slice(prefix.length, -2));
+}
+
 {
   const harness = createHarness([{ completeBeforeReply: true, completion: completion() }]);
   const result = await execute(harness.tool, { tasks: [{ agent: "reviewer", task: "Review" }] });
@@ -89,6 +98,44 @@ async function executeFailure(tool, params, signal = new AbortController().signa
   assert.equal(result.details.gate.status, "satisfied");
   assert.equal(result.details.gate.qualifyingSuccesses, 1);
   assert.equal(result.details.gate.attempts.length, 1, "completion emitted before the spawn reply should be recovered from the cache");
+  const spawn = harness.requests.find((request) => request.method === "spawn");
+  assert.equal(spawn.params.agent, undefined, "public RPC must not use removed direct execution");
+  assert.equal(spawn.params.task, undefined, "public RPC must not use removed direct execution");
+  assert.equal(spawn.params.async, true, "the wrapper workflow must remain asynchronous");
+  assert.deepEqual(workflowChildParams(spawn), { agent: "reviewer", task: "Review", async: false });
+  harness.dispose();
+}
+
+{
+  const harness = createHarness([{ completion: completion({ output: "All child controls preserved" }) }]);
+  await execute(harness.tool, {
+    attemptTimeoutMs: 4567,
+    tasks: [{
+      agent: "reviewer",
+      task: "Review quoted task: `x`",
+      model: "openai/gpt-5.4",
+      context: "fresh",
+      cwd: "/tmp/repo",
+      skill: ["audit"],
+      output: "summary",
+      outputMode: "inline",
+      acceptance: { verify: true },
+    }],
+  });
+  const spawn = harness.requests.find((request) => request.method === "spawn");
+  assert.equal(spawn.params.timeoutMs, 4567);
+  assert.deepEqual(workflowChildParams(spawn), {
+    agent: "reviewer",
+    task: "Review quoted task: `x`",
+    model: "openai/gpt-5.4",
+    context: "fresh",
+    cwd: "/tmp/repo",
+    skill: ["audit"],
+    output: "summary",
+    outputMode: "inline",
+    acceptance: { verify: true },
+    async: false,
+  });
   harness.dispose();
 }
 


### PR DESCRIPTION
## Problem
`subagent_gate` sent public `spawn` RPC calls with direct `agent` and `task` fields. Current pi-subagents rejects that contract before launch.

## Change
- wrap each child in public `workflowScript` using `runs.run`
- keep the outer workflow asynchronous but await the child foreground result
- cover the public request shape and all forwarded task controls

## Verification
- `node tests/subagent-gate.test.mjs`
- `node --check lib/subagent-gate.mjs`
- pi-subagents public execution normalizer smoke

## Known gap
The package-wide suite currently has unrelated existing harness/documentation failures; this PR does not change those files.